### PR TITLE
docs: trim and refresh AGENTS guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,50 +3,26 @@
 ## Project Overview
 This is a Next.js TypeScript application for analyzing CSV data containing user request analytics and quota information.
 
-## Key Technologies
-- Next.js 16 with App Router
-- TypeScript
-- Tailwind CSS
-- Recharts for data visualization
-- PapaParse for CSV parsing
-
-## Code Style Guidelines
-- Use functional components with React hooks
-- Use Tailwind CSS for all styling
-- Follow Next.js App Router conventions
-- Use meaningful component and variable names
-- Include proper error handling for file operations
-- Ensure components are accessible and responsive
-- **ALWAYS use constants from `/src/constants/pricing.ts` instead of hardcoding values**
-- **NEVER duplicate pricing-related magic numbers - import from PRICING constants**
+## Project Rules
+- **ALWAYS use constants from `/src/constants/pricing.ts` instead of hardcoding pricing or quota values**
 
 ## Data Structure
-The CSV data follows this format:
+The app ingests the expanded billing export. Core fields include:
 ```
-Timestamp,User,Model,Requests Used,Exceeds Monthly Quota,Total Monthly Quota
-2025-06-03T11:05:27Z,USerA,gpt-4.1-2025-04-14,1.00,false,Unlimited
+date,username,product,sku,model,quantity,exceeds_quota,total_monthly_quota,applied_cost_per_quantity,gross_amount,discount_amount,net_amount,organization,cost_center_name
+2026-03-11,userA,copilot,copilot_premium_request,Code Review model,2,TRUE,1000,0.04,0.08,0,0.08,example-org,APP-10009666 CostCenter 5900877
 ```
+- Quota values can be `Unlimited`, `300`, or `1000`
+- Billing fields may be absent in older datasets, so ingestion must handle optional commercial columns
+- Organization and cost center fields are supported throughout the app
 
 ## Date Handling - CRITICAL
 **NEVER convert dates to local timezone.** This is a billing report and date accuracy is crucial:
-- Always treat timestamps exactly as they appear in the CSV
+- Always treat the CSV date/timestamp exactly as provided
 - If a timestamp says "June 30th, 2025 at 23:59:59Z", it should be treated as June 30th, 2025
 - Billing periods start on the 1st day of the month and end on the last day of the month
 - Use UTC dates consistently throughout the application
 - When grouping by months/days, use the exact date from the timestamp without timezone conversion
 
-## Quota Types Support
-The application supports mixed quota types in the Total Monthly Quota column:
-- "Unlimited" - No quota limit
-- "300" - Business SKU (300 premium requests per month)
-- "1000" - Enterprise SKU (1000 premium requests per month)
-- Mixed environments are supported with appropriate UI indicators
-
 ## Git Workflow
 When it's time to commit, push, create or update a PR, or clean up after a merge, delegate to the `git-workflow` skill (`.github/skills/git-workflow/SKILL.md`).
-
-## Component Architecture
-- Keep components small and focused on single responsibilities
-- Use proper TypeScript typing for all props and state
-- Implement proper loading states and error handling
-- Use React best practices for performance optimization


### PR DESCRIPTION
## Summary
Tighten `AGENTS.md` so it reflects the current repo and spends tokens on repo-specific guidance instead of generic engineering advice.

| Commit | Change |
|--------|--------|
| `docs: trim and refresh AGENTS guidance` | Replaced the stale CSV example with the current expanded billing export shape, kept the critical UTC/pricing/git rules, and removed generic low-signal guidance that duplicates runtime instructions or is easy to infer from the repo. |

## Validation
- `npm run build`
- `npm run lint`
- `npm run test`