### PR TITLE
Refactor usage artifact accumulation

### DIFF
--- a/__tests__/utils/usageAggregator.test.ts
+++ b/__tests__/utils/usageAggregator.test.ts
@@ -1,5 +1,6 @@
 import { PRICING } from '@/constants/pricing';
-import { AggregatorContext, NormalizedRow, UsageAggregator } from '@/utils/ingestion';
+import { AggregatorContext, NormalizedRow, UsageAggregator, buildUsageArtifactsFromProcessedData } from '@/utils/ingestion';
+import type { ProcessedData } from '@/types/csv';
 
 function makeRow(partial: Partial<NormalizedRow>): NormalizedRow {
   return {
@@ -29,10 +30,10 @@ describe('UsageAggregator', () => {
     agg.init?.(ctx);
 
     const rows: NormalizedRow[] = [
-      makeRow({ user: 'alice', organization: 'Org B', costCenter: 'Platform', quantity: 2 }),
-      makeRow({ user: 'alice', model: 'gpt-4.1', quantity: 3 }),
-      makeRow({ user: 'bob', organization: 'Org A', costCenter: 'Security', quantity: 1 }),
-      makeRow({ user: 'carol', costCenter: 'Security', quantity: 4 }),
+      makeRow({ user: 'test-user-one', organization: 'test-org-two', costCenter: 'test-cost-center-one', quantity: 2 }),
+      makeRow({ user: 'test-user-one', model: 'gpt-4.1', quantity: 3 }),
+      makeRow({ user: 'test-user-two', organization: 'test-org-one', costCenter: 'test-cost-center-two', quantity: 1 }),
+      makeRow({ user: 'test-user-three', costCenter: 'test-cost-center-two', quantity: 4 }),
     ];
 
     for (const row of rows) {
@@ -41,12 +42,12 @@ describe('UsageAggregator', () => {
 
     const output = agg.finalize(ctx);
 
-    expect(output.organizations).toEqual(['Org A', 'Org B']);
-    expect(output.costCenters).toEqual(['Platform', 'Security']);
+    expect(output.organizations).toEqual(['test-org-one', 'test-org-two']);
+    expect(output.costCenters).toEqual(['test-cost-center-one', 'test-cost-center-two']);
     expect(output.users).toEqual(expect.arrayContaining([
-      expect.objectContaining({ user: 'alice', organization: 'Org B', costCenter: 'Platform', totalRequests: 5 }),
-      expect.objectContaining({ user: 'bob', organization: 'Org A', costCenter: 'Security', totalRequests: 1 }),
-      expect.objectContaining({ user: 'carol', organization: undefined, costCenter: 'Security', totalRequests: 4 }),
+      expect.objectContaining({ user: 'test-user-one', organization: 'test-org-two', costCenter: 'test-cost-center-one', totalRequests: 5 }),
+      expect.objectContaining({ user: 'test-user-two', organization: 'test-org-one', costCenter: 'test-cost-center-two', totalRequests: 1 }),
+      expect.objectContaining({ user: 'test-user-three', organization: undefined, costCenter: 'test-cost-center-two', totalRequests: 4 }),
     ]));
   });
 
@@ -60,12 +61,12 @@ describe('UsageAggregator', () => {
       isNonCopilotUsage: true,
       usageBucket: 'non_copilot_code_review'
     }, ctx);
-    agg.onRow(makeRow({ user: 'alice', model: 'gpt-4.1', quantity: 2 }), ctx);
+    agg.onRow(makeRow({ user: 'test-user-one', model: 'gpt-4.1', quantity: 2 }), ctx);
 
     const output = agg.finalize(ctx);
 
     expect(output.users).toHaveLength(1);
-    expect(output.users[0].user).toBe('alice');
+    expect(output.users[0].user).toBe('test-user-one');
     expect(output.specialBuckets).toEqual([
       expect.objectContaining({
         key: 'non_copilot_code_review',
@@ -73,6 +74,78 @@ describe('UsageAggregator', () => {
         quotaValue: 0,
         modelBreakdown: { 'Code Review': 6 }
       })
+    ]);
+  });
+
+  test('processed data builder matches UsageAggregator output and includes top model metadata', () => {
+    const ctx: AggregatorContext = { pricing: PRICING };
+    const rows: NormalizedRow[] = [
+      makeRow({
+        user: 'test-user-one',
+        model: 'model-one',
+        quantity: 2,
+        organization: 'test-org-one',
+        costCenter: 'test-cost-center-one',
+      }),
+      makeRow({
+        user: 'test-user-one',
+        model: 'model-two',
+        quantity: 5,
+      }),
+      makeRow({
+        user: 'test-user-two',
+        model: 'model-one',
+        quantity: 3,
+        organization: 'test-org-two',
+        costCenter: 'test-cost-center-two',
+      }),
+      {
+        ...makeRow({ user: '', model: 'Code Review', quantity: 4 }),
+        isNonCopilotUsage: true,
+        usageBucket: 'non_copilot_code_review',
+      },
+    ];
+    const agg = new UsageAggregator();
+    agg.init?.(ctx);
+    for (const row of rows) {
+      agg.onRow(row, ctx);
+    }
+
+    const processedRows: ProcessedData[] = rows.map((row) => ({
+      timestamp: new Date(`${row.day}T00:00:00Z`),
+      user: row.user,
+      model: row.model,
+      requestsUsed: row.quantity,
+      exceedsQuota: row.exceedsQuota ?? false,
+      totalQuota: row.quotaRaw ?? 'Unlimited',
+      quotaValue: row.quotaValue ?? 'unlimited',
+      iso: `${row.day}T00:00:00.000Z`,
+      dateKey: row.day,
+      monthKey: row.day.slice(0, 7),
+      epoch: new Date(`${row.day}T00:00:00Z`).getTime(),
+      organization: row.organization,
+      costCenter: row.costCenter,
+      isNonCopilotUsage: row.isNonCopilotUsage,
+      usageBucket: row.usageBucket,
+    }));
+
+    const streamingOutput = agg.finalize(ctx);
+    const processedOutput = buildUsageArtifactsFromProcessedData(processedRows);
+
+    expect(processedOutput).toEqual(streamingOutput);
+    expect(processedOutput.users).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        user: 'test-user-one',
+        topModel: 'model-two',
+        topModelValue: 5,
+      }),
+    ]));
+    expect(processedOutput.specialBuckets).toEqual([
+      expect.objectContaining({
+        key: 'non_copilot_code_review',
+        totalRequests: 4,
+        modelBreakdown: { 'Code Review': 4 },
+      }),
     ]);
   });
 });

--- a/src/components/CSVUploader.tsx
+++ b/src/components/CSVUploader.tsx
@@ -78,8 +78,8 @@ export function CSVUploader({ onDataLoad, onError }: CSVUploaderProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [isSampleLoading, setIsSampleLoading] = useState(false);
   const [progress, setProgress] = useState(0);
+  const [totalRowsProcessed, setTotalRowsProcessed] = useState(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const totalRows = useRef(0);
 
   const isBusy = isLoading || isSampleLoading;
 
@@ -92,7 +92,7 @@ export function CSVUploader({ onDataLoad, onError }: CSVUploaderProps) {
     // Reset state
     setIsLoading(true);
     setProgress(0);
-    totalRows.current = 0;
+    setTotalRowsProcessed(0);
 
     // Create all aggregators including raw data collector for adapter
     const quotaAggregator = new QuotaAggregator();
@@ -110,7 +110,7 @@ export function CSVUploader({ onDataLoad, onError }: CSVUploaderProps) {
         chunkSize: 1024 * 1024, // 1MB chunks for smooth UI
         progressResolution: 1000,
         onProgress: (progressInfo) => {
-          totalRows.current = progressInfo.rowsProcessed;
+          setTotalRowsProcessed(progressInfo.rowsProcessed);
           // Estimate progress percentage
           setProgress(prev => Math.min(prev + 5, 90));
         },
@@ -122,6 +122,7 @@ export function CSVUploader({ onDataLoad, onError }: CSVUploaderProps) {
             onError('CSV file is empty');
             setIsLoading(false);
             setProgress(0);
+            setTotalRowsProcessed(0);
             return;
           }
           
@@ -130,12 +131,14 @@ export function CSVUploader({ onDataLoad, onError }: CSVUploaderProps) {
             onDataLoad(result, file.name);
             setIsLoading(false);
             setProgress(0);
+            setTotalRowsProcessed(0);
           }, 200);
         },
         onError: (errorMsg) => {
           onError(errorMsg);
           setIsLoading(false);
           setProgress(0);
+          setTotalRowsProcessed(0);
         }
       }
     );
@@ -159,6 +162,7 @@ export function CSVUploader({ onDataLoad, onError }: CSVUploaderProps) {
       const message = error instanceof Error ? error.message : 'Failed to load sample data';
       onError(message);
       setProgress(0);
+      setTotalRowsProcessed(0);
     } finally {
       setIsSampleLoading(false);
     }
@@ -275,9 +279,9 @@ export function CSVUploader({ onDataLoad, onError }: CSVUploaderProps) {
                         />
                       </div>
                     </div>
-                    {totalRows.current > 0 && (
+                    {totalRowsProcessed > 0 && (
                       <p className="text-sm text-[#636c76]">
-                        {totalRows.current.toLocaleString()} rows processed
+                        {totalRowsProcessed.toLocaleString()} rows processed
                       </p>
                     )}
                   </div>

--- a/src/utils/ingestion/UsageAccumulator.ts
+++ b/src/utils/ingestion/UsageAccumulator.ts
@@ -1,0 +1,122 @@
+import {
+  NON_COPILOT_CODE_REVIEW_LABEL,
+  type SpecialUsageBucketAggregate,
+  type SpecialUsageBucketKey,
+  type UsageArtifacts,
+  type UserAggregate,
+} from './types';
+
+export interface UsageAccumulationRow {
+  user: string;
+  model: string;
+  quantity: number;
+  organization?: string;
+  costCenter?: string;
+  isNonCopilotUsage?: boolean;
+  usageBucket?: SpecialUsageBucketKey;
+}
+
+export class UsageAccumulator {
+  private userTotals = new Map<string, number>();
+  private userModelTotals = new Map<string, Map<string, number>>();
+  private modelTotals = new Map<string, number>();
+  private topModelPerUser = new Map<string, { model: string; value: number }>();
+  private userMetadata = new Map<string, { organization?: string; costCenter?: string }>();
+  private organizations = new Set<string>();
+  private costCenters = new Set<string>();
+  private specialBuckets = new Map<SpecialUsageBucketKey, SpecialUsageBucketAggregate>();
+
+  addRow(row: UsageAccumulationRow): void {
+    if (row.isNonCopilotUsage && row.usageBucket) {
+      let bucket = this.specialBuckets.get(row.usageBucket);
+      if (!bucket) {
+        bucket = {
+          key: row.usageBucket,
+          label: NON_COPILOT_CODE_REVIEW_LABEL,
+          totalRequests: 0,
+          modelBreakdown: {},
+          quotaValue: 0,
+        };
+        this.specialBuckets.set(row.usageBucket, bucket);
+      }
+      bucket.totalRequests += row.quantity;
+      bucket.modelBreakdown[row.model] = (bucket.modelBreakdown[row.model] || 0) + row.quantity;
+      this.modelTotals.set(row.model, (this.modelTotals.get(row.model) || 0) + row.quantity);
+      return;
+    }
+
+    const { user, model, quantity, organization, costCenter } = row;
+
+    this.userTotals.set(user, (this.userTotals.get(user) || 0) + quantity);
+
+    let modelMap = this.userModelTotals.get(user);
+    if (!modelMap) {
+      modelMap = new Map();
+      this.userModelTotals.set(user, modelMap);
+    }
+    const newModelTotal = (modelMap.get(model) || 0) + quantity;
+    modelMap.set(model, newModelTotal);
+
+    if (organization) {
+      this.organizations.add(organization);
+    }
+    if (costCenter) {
+      this.costCenters.add(costCenter);
+    }
+
+    const metadata = this.userMetadata.get(user) ?? {};
+    if (!metadata.organization && organization) {
+      metadata.organization = organization;
+    }
+    if (!metadata.costCenter && costCenter) {
+      metadata.costCenter = costCenter;
+    }
+    this.userMetadata.set(user, metadata);
+
+    this.modelTotals.set(model, (this.modelTotals.get(model) || 0) + quantity);
+
+    const top = this.topModelPerUser.get(user);
+    if (!top || newModelTotal > top.value) {
+      this.topModelPerUser.set(user, { model, value: newModelTotal });
+    }
+  }
+
+  finalize(): UsageArtifacts {
+    const users: UserAggregate[] = [];
+
+    for (const [user, totalRequests] of this.userTotals) {
+      const modelMap = this.userModelTotals.get(user);
+      if (!modelMap) {
+        continue;
+      }
+
+      const modelBreakdown: Record<string, number> = {};
+      for (const [model, value] of modelMap) {
+        modelBreakdown[model] = value;
+      }
+
+      const topEntry = this.topModelPerUser.get(user);
+      const metadata = this.userMetadata.get(user);
+
+      users.push({
+        user,
+        totalRequests,
+        modelBreakdown,
+        topModel: topEntry?.model,
+        topModelValue: topEntry?.value,
+        organization: metadata?.organization,
+        costCenter: metadata?.costCenter,
+      });
+    }
+
+    return {
+      users,
+      modelTotals: Object.fromEntries(this.modelTotals),
+      userCount: this.userTotals.size,
+      modelCount: this.modelTotals.size,
+      organizations: Array.from(this.organizations).sort((left, right) => left.localeCompare(right)),
+      costCenters: Array.from(this.costCenters).sort((left, right) => left.localeCompare(right)),
+      specialBuckets: Array.from(this.specialBuckets.values()),
+    };
+  }
+}

--- a/src/utils/ingestion/UsageAggregator.ts
+++ b/src/utils/ingestion/UsageAggregator.ts
@@ -6,133 +6,28 @@
 import {
   Aggregator,
   AggregatorContext,
-  NON_COPILOT_CODE_REVIEW_LABEL,
   NormalizedRow,
-  SpecialUsageBucketKey,
-  SpecialUsageBucketAggregate,
   UsageArtifacts,
-  UserAggregate
 } from './types';
+import { UsageAccumulator } from './UsageAccumulator';
 
 export class UsageAggregator implements Aggregator<UsageArtifacts> {
   readonly id = 'usage';
-  
-  private userTotals = new Map<string, number>();
-  private userModelTotals = new Map<string, Map<string, number>>();
-  private modelTotals = new Map<string, number>();
-  private topModelPerUser = new Map<string, { model: string; value: number }>();
-  private userMetadata = new Map<string, { organization?: string; costCenter?: string }>();
-  private organizations = new Set<string>();
-  private costCenters = new Set<string>();
-  private specialBuckets = new Map<SpecialUsageBucketKey, SpecialUsageBucketAggregate>();
+
+  private accumulator = new UsageAccumulator();
   
   init(_ctx: AggregatorContext): void {
     void _ctx;
-    // Reset state
-    this.userTotals.clear();
-    this.userModelTotals.clear();
-    this.modelTotals.clear();
-    this.topModelPerUser.clear();
-    this.userMetadata.clear();
-    this.organizations.clear();
-    this.costCenters.clear();
-    this.specialBuckets.clear();
+    this.accumulator = new UsageAccumulator();
   }
   
   onRow(row: NormalizedRow, _ctx: AggregatorContext): void {
     void _ctx;
-    if (row.isNonCopilotUsage && row.usageBucket) {
-      let bucket = this.specialBuckets.get(row.usageBucket);
-      if (!bucket) {
-        bucket = {
-          key: row.usageBucket,
-          label: NON_COPILOT_CODE_REVIEW_LABEL,
-          totalRequests: 0,
-          modelBreakdown: {},
-          quotaValue: 0
-        };
-        this.specialBuckets.set(row.usageBucket, bucket);
-      }
-      bucket.totalRequests += row.quantity;
-      bucket.modelBreakdown[row.model] = (bucket.modelBreakdown[row.model] || 0) + row.quantity;
-      this.modelTotals.set(row.model, (this.modelTotals.get(row.model) || 0) + row.quantity);
-      return;
-    }
-
-    const { user, model, quantity, organization, costCenter } = row;
-    
-    // User totals
-    this.userTotals.set(user, (this.userTotals.get(user) || 0) + quantity);
-    
-    // User-model breakdown
-    let modelMap = this.userModelTotals.get(user);
-    if (!modelMap) {
-      modelMap = new Map();
-      this.userModelTotals.set(user, modelMap);
-    }
-    const newModelTotal = (modelMap.get(model) || 0) + quantity;
-    modelMap.set(model, newModelTotal);
-
-    if (organization) {
-      this.organizations.add(organization);
-    }
-    if (costCenter) {
-      this.costCenters.add(costCenter);
-    }
-
-    const metadata = this.userMetadata.get(user) ?? {};
-    if (!metadata.organization && organization) {
-      metadata.organization = organization;
-    }
-    if (!metadata.costCenter && costCenter) {
-      metadata.costCenter = costCenter;
-    }
-    this.userMetadata.set(user, metadata);
-    
-    // Global model totals
-    this.modelTotals.set(model, (this.modelTotals.get(model) || 0) + quantity);
-    
-    // Track top model per user (avoid sorting later)
-    const top = this.topModelPerUser.get(user);
-    if (!top || newModelTotal > top.value) {
-      this.topModelPerUser.set(user, { model, value: newModelTotal });
-    }
+    this.accumulator.addRow(row);
   }
   
   finalize(_ctx: AggregatorContext): UsageArtifacts {
     void _ctx;
-    const users: UserAggregate[] = [];
-    
-    for (const [user, totalRequests] of this.userTotals) {
-      const modelMap = this.userModelTotals.get(user)!;
-      const modelBreakdown: Record<string, number> = {};
-      
-      for (const [m, val] of modelMap) {
-        modelBreakdown[m] = val;
-      }
-      
-      const topEntry = this.topModelPerUser.get(user);
-      const metadata = this.userMetadata.get(user);
-      
-      users.push({
-        user,
-        totalRequests,
-        modelBreakdown,
-        topModel: topEntry?.model,
-        topModelValue: topEntry?.value,
-        organization: metadata?.organization,
-        costCenter: metadata?.costCenter
-      });
-    }
-    
-    return {
-      users,
-      modelTotals: Object.fromEntries(this.modelTotals),
-      userCount: this.userTotals.size,
-      modelCount: this.modelTotals.size,
-      organizations: Array.from(this.organizations).sort((a, b) => a.localeCompare(b)),
-      costCenters: Array.from(this.costCenters).sort((a, b) => a.localeCompare(b)),
-      specialBuckets: Array.from(this.specialBuckets.values())
-    };
+    return this.accumulator.finalize();
   }
 }

--- a/src/utils/ingestion/analytics.ts
+++ b/src/utils/ingestion/analytics.ts
@@ -12,6 +12,13 @@
 import { PRICING } from '@/constants/pricing';
 import type { AnalysisResults, ProcessedData } from '@/types/csv';
 import type { CodeReviewAnalysis } from '@/types/csv';
+import { CodingAgentAnalysis, UserDailyData } from '@/types/csv';
+import { Advisory as LegacyAdvisory } from '@/utils/analytics/advisory';
+import { CONSUMPTION_THRESHOLDS, UserConsumptionCategory, InsightsOverviewData } from '@/utils/analytics/insights';
+import type { FeatureUtilizationStats } from '@/utils/analytics/insights';
+import { buildUserQuotaMapFromRows } from '@/utils/analytics/quota';
+import { isCodeReviewModel, isCodingAgentModel } from '@/utils/productClassification';
+import { calculateBilledOverageFromRows, calculateOverageRequests, calculateOverageCost } from '@/utils/userCalculations';
 import {
   NON_COPILOT_CODE_REVIEW_BUCKET,
   type DailyBucketsArtifacts,
@@ -19,17 +26,12 @@ import {
   type QuotaArtifacts,
   type UsageArtifacts,
 } from './types';
-export type { DailyBucketsArtifacts } from './types';
 import { UsageAccumulator } from './UsageAccumulator';
-import type { FeatureUtilizationStats } from '@/utils/analytics/insights';
-import { calculateBilledOverageFromRows, calculateOverageRequests, calculateOverageCost } from '@/utils/userCalculations';
-import { CodingAgentAnalysis, UserDailyData } from '@/types/csv';
+
+export type { DailyBucketsArtifacts } from './types';
+
 // Legacy DailyCodingAgentUsageDatum type recreated locally (originally from codingAgent.ts)
 export interface DailyCodingAgentUsageDatum { date: string; dailyRequests: number; cumulativeRequests: number; }
-import { CONSUMPTION_THRESHOLDS, UserConsumptionCategory, InsightsOverviewData } from '@/utils/analytics/insights';
-import { buildUserQuotaMapFromRows } from '@/utils/analytics/quota';
-import { Advisory as LegacyAdvisory } from '@/utils/analytics/advisory';
-import { isCodeReviewModel, isCodingAgentModel } from '@/utils/productClassification';
 
 const NON_COPILOT_CODE_REVIEW_ADOPTION_LABEL = 'Non-Copilot Users';
 

--- a/src/utils/ingestion/analytics.ts
+++ b/src/utils/ingestion/analytics.ts
@@ -14,14 +14,13 @@ import type { AnalysisResults, ProcessedData } from '@/types/csv';
 import type { CodeReviewAnalysis } from '@/types/csv';
 import {
   NON_COPILOT_CODE_REVIEW_BUCKET,
-  NON_COPILOT_CODE_REVIEW_LABEL,
-  type SpecialUsageBucketKey,
   type DailyBucketsArtifacts,
   type FeatureUsageArtifacts,
   type QuotaArtifacts,
   type UsageArtifacts,
 } from './types';
 export type { DailyBucketsArtifacts } from './types';
+import { UsageAccumulator } from './UsageAccumulator';
 import type { FeatureUtilizationStats } from '@/utils/analytics/insights';
 import { calculateBilledOverageFromRows, calculateOverageRequests, calculateOverageCost } from '@/utils/userCalculations';
 import { CodingAgentAnalysis, UserDailyData } from '@/types/csv';
@@ -45,76 +44,20 @@ export function buildTimeFrame(daily: DailyBucketsArtifacts): { start: string; e
  * Used when billing period (selectedMonths) is active to produce month-sliced
  * artifacts for downstream analysis functions.
  */
-export function buildUsageArtifactsFromProcessedData(filtered: import('@/types/csv').ProcessedData[]): UsageArtifacts {
-  const userMap = new Map<string, {
-    totalRequests: number;
-    modelBreakdown: Record<string, number>;
-    organization?: string;
-    costCenter?: string;
-  }>();
-  const specialBucketMap = new Map<SpecialUsageBucketKey, {
-    totalRequests: number;
-    modelBreakdown: Record<string, number>;
-  }>();
-  const modelTotals: Record<string, number> = {};
-  const organizations = new Set<string>();
-  const costCenters = new Set<string>();
+export function buildUsageArtifactsFromProcessedData(filtered: ProcessedData[]): UsageArtifacts {
+  const accumulator = new UsageAccumulator();
   for (const r of filtered) {
-    if (r.isNonCopilotUsage && r.usageBucket) {
-      const bucket = specialBucketMap.get(r.usageBucket) ?? { totalRequests: 0, modelBreakdown: {} };
-      bucket.totalRequests += r.requestsUsed;
-      bucket.modelBreakdown[r.model] = (bucket.modelBreakdown[r.model] || 0) + r.requestsUsed;
-      specialBucketMap.set(r.usageBucket, bucket);
-      modelTotals[r.model] = (modelTotals[r.model] || 0) + r.requestsUsed;
-      continue;
-    }
-    if (!userMap.has(r.user)) {
-      userMap.set(r.user, {
-        totalRequests: 0,
-        modelBreakdown: {},
-        organization: r.organization,
-        costCenter: r.costCenter
-      });
-    }
-    const u = userMap.get(r.user)!;
-    u.totalRequests += r.requestsUsed;
-    u.modelBreakdown[r.model] = (u.modelBreakdown[r.model] || 0) + r.requestsUsed;
-    if (!u.organization && r.organization) {
-      u.organization = r.organization;
-    }
-    if (!u.costCenter && r.costCenter) {
-      u.costCenter = r.costCenter;
-    }
-    modelTotals[r.model] = (modelTotals[r.model] || 0) + r.requestsUsed;
-    if (r.organization) {
-      organizations.add(r.organization);
-    }
-    if (r.costCenter) {
-      costCenters.add(r.costCenter);
-    }
+    accumulator.addRow({
+      user: r.user,
+      model: r.model,
+      quantity: r.requestsUsed,
+      organization: r.organization,
+      costCenter: r.costCenter,
+      isNonCopilotUsage: r.isNonCopilotUsage,
+      usageBucket: r.usageBucket,
+    });
   }
-  const users = Array.from(userMap.entries()).map(([user, data]) => ({
-    user,
-    totalRequests: data.totalRequests,
-    modelBreakdown: data.modelBreakdown,
-    organization: data.organization,
-    costCenter: data.costCenter,
-  }));
-  return {
-    users,
-    modelTotals,
-    userCount: users.length,
-    modelCount: Object.keys(modelTotals).length,
-    organizations: Array.from(organizations).sort((a, b) => a.localeCompare(b)),
-    costCenters: Array.from(costCenters).sort((a, b) => a.localeCompare(b)),
-    specialBuckets: Array.from(specialBucketMap.entries()).map(([key, value]) => ({
-      key,
-      label: NON_COPILOT_CODE_REVIEW_LABEL,
-      totalRequests: value.totalRequests,
-      modelBreakdown: value.modelBreakdown,
-      quotaValue: 0
-    }))
-  };
+  return accumulator.finalize();
 }
 
 /**

--- a/src/utils/ingestion/index.ts
+++ b/src/utils/ingestion/index.ts
@@ -8,6 +8,7 @@ export * from './normalizeRow';
 export * from './orchestrator';
 export * from './QuotaAggregator';
 export * from './UsageAggregator';
+export * from './UsageAccumulator';
 export * from './DailyBucketsAggregator';
 export * from './BillingAggregator';
 export * from './FeatureUsageAggregator';


### PR DESCRIPTION
Issue #71 identified that `buildUsageArtifactsFromProcessedData` reimplemented the same accumulation rules as `UsageAggregator`, which made month-filtered usage artifacts easy to drift from the streaming ingestion path. This PR keeps the two necessary entry points, but moves the actual usage math into a shared accumulator so filtered and full-report artifacts stay consistent.

## Summary

| Commit | Change |
|--------|--------|
| `refactor:` share usage aggregation logic | Adds `UsageAccumulator` as the single source of truth for user totals, model totals, top-model metadata, organizations, cost centers, and special non-Copilot buckets. `UsageAggregator` and `buildUsageArtifactsFromProcessedData` now delegate to it. |
| `fix:` avoid CSV uploader ref reads during render | Replaces render-time reads of `totalRows.current` with React state so the repository lint check passes. |
| `chore:` keep analytics imports together | Addresses Cloud Code Review feedback by keeping imports grouped before the `DailyBucketsArtifacts` type re-export, including the quota helper import added on `main`. |

## Notes

The month-filtered path still rebuilds usage artifacts from filtered rows because selected billing periods need sliced artifacts at render time. The difference is that it now adapts `ProcessedData` into the shared accumulator instead of duplicating accumulation logic.

## Validation

- `npm run build && npm run lint && npm run test`
