### PR TITLE
Refactor feature utilization to use ingestion artifacts

### DIFF
--- a/__tests__/components/CodingAgentOverview.test.tsx
+++ b/__tests__/components/CodingAgentOverview.test.tsx
@@ -43,7 +43,11 @@ function createContextValue() {
       dailyUserModelTotals: new Map(),
       dateRange: { min: '2025-06-01', max: '2025-06-02' },
     } as DailyBucketsArtifacts,
-    featureUsageArtifacts: undefined as FeatureUsageArtifacts | undefined,
+    featureUsageArtifacts: {
+      featureTotals: { codeReview: 0, codingAgent: 0, spark: 0 },
+      featureUsers: { codeReview: new Set(), codingAgent: new Set(), spark: new Set() },
+      specialTotals: { nonCopilotCodeReview: 0 },
+    } as FeatureUsageArtifacts,
     billingArtifacts: undefined as BillingArtifacts | undefined,
     baseProcessed: [] as ProcessedData[],
     processedData: [] as ProcessedData[],
@@ -89,7 +93,7 @@ describe('CodingAgentOverview', () => {
       adoptionRate: 66.67,
       users: [
         {
-          user: 'bob',
+          user: 'test-user-one',
           totalRequests: 10,
           codeReviewRequests: 8,
           codeReviewPercentage: 80,
@@ -97,7 +101,7 @@ describe('CodingAgentOverview', () => {
           models: ['Code Review beta'],
         },
         {
-          user: 'alice',
+          user: 'test-user-two',
           totalRequests: 20,
           codeReviewRequests: 5,
           codeReviewPercentage: 25,

--- a/__tests__/components/DataAnalysisBilling.test.tsx
+++ b/__tests__/components/DataAnalysisBilling.test.tsx
@@ -5,7 +5,7 @@ import { newFormatRows } from '../fixtures/newFormatCSVData';
 import type { CSVData } from '@/types/csv';
 import { normalizeRow } from '@/utils/ingestion/normalizeRow';
 import type { IngestionResult } from '@/utils/ingestion';
-import type { NormalizedRow } from '@/utils/ingestion/types';
+import type { FeatureUsageArtifacts, NormalizedRow } from '@/utils/ingestion/types';
 
 // Mock ResizeObserver for Recharts ResponsiveContainer in JSDOM
 beforeAll(() => {
@@ -22,12 +22,18 @@ function createIngestionResultFromRawRows(rows: CSVData[]): IngestionResult {
   const normalizedRows = rows
     .map(row => normalizeRow(row, warnings))
     .filter((row): row is NormalizedRow => row !== null);
+  const emptyFeatureUsage: FeatureUsageArtifacts = {
+    featureTotals: { codeReview: 0, codingAgent: 0, spark: 0 },
+    featureUsers: { codeReview: new Set(), codingAgent: new Set(), spark: new Set() },
+    specialTotals: { nonCopilotCodeReview: 0 }
+  };
 
   return {
     outputs: {
       'quota': { quotaByUser: new Map(), conflicts: new Map(), distinctQuotas: new Set(), hasMixedQuotas: false, hasMixedLicenses: false },
       'usage': { users: [], userTotals: new Map(), modelBreakdown: new Map(), globalModelTotals: new Map(), topModelPerUser: new Map(), modelTotals: {}, userCount: 0, modelCount: 0 },
       'dailyBuckets': { dailyUserTotals: new Map(), startDate: new Date(), endDate: new Date() },
+      'featureUsage': emptyFeatureUsage,
       'rawData': normalizedRows
     },
     rowsProcessed: normalizedRows.length,

--- a/__tests__/components/MissingRawDataAggregator.test.tsx
+++ b/__tests__/components/MissingRawDataAggregator.test.tsx
@@ -20,8 +20,27 @@ function createIngestionResultWithoutRawData(): IngestionResult {
     outputs: {
       quota: { quotaByUser: new Map(), conflicts: new Map(), distinctQuotas: new Set(), hasMixedQuotas: false, hasMixedLicenses: false },
       usage: { users: [], modelTotals: {}, userCount: 0, modelCount: 0 },
-      dailyBuckets: { dailyUserTotals: new Map(), dateRange: null, months: [] }
+      dailyBuckets: { dailyUserTotals: new Map(), dateRange: null, months: [] },
+      featureUsage: {
+        featureTotals: { codeReview: 0, codingAgent: 0, spark: 0 },
+        featureUsers: { codeReview: new Set(), codingAgent: new Set(), spark: new Set() },
+        specialTotals: { nonCopilotCodeReview: 0 }
+      }
       // Intentionally no rawData aggregator output
+    },
+    rowsProcessed: 0,
+    durationMs: 0,
+    warnings: []
+  };
+}
+
+function createIngestionResultWithoutFeatureUsage(): IngestionResult {
+  return {
+    outputs: {
+      quota: { quotaByUser: new Map(), conflicts: new Map(), distinctQuotas: new Set(), hasMixedQuotas: false, hasMixedLicenses: false },
+      usage: { users: [], modelTotals: {}, userCount: 0, modelCount: 0 },
+      dailyBuckets: { dailyUserTotals: new Map(), dateRange: null, months: [] },
+      rawData: []
     },
     rowsProcessed: 0,
     durationMs: 0,
@@ -35,5 +54,15 @@ describe('AnalysisProvider without rawData aggregator', () => {
     render(<DataAnalysis ingestionResult={ingestionResult} filename="no-raw.csv" onReset={() => {}} />);
     // Info bar should render with the filename
     expect(screen.getByText('no-raw.csv')).toBeInTheDocument();
+  });
+
+  it('throws a clear error when featureUsage artifacts are missing', () => {
+    const ingestionResult = createIngestionResultWithoutFeatureUsage();
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => render(<DataAnalysis ingestionResult={ingestionResult} filename="no-feature.csv" onReset={() => {}} />))
+      .toThrow('Missing or invalid featureUsage output in ingestion result');
+
+    consoleError.mockRestore();
   });
 });

--- a/__tests__/utils/insights.test.ts
+++ b/__tests__/utils/insights.test.ts
@@ -1,14 +1,17 @@
 import { PRICING } from '@/constants/pricing';
-import { categorizeUserConsumption, calculateUnusedValue, CONSUMPTION_THRESHOLDS, UserConsumptionCategory, calculateFeatureUtilization } from '@/utils/analytics/insights';
-import { ProcessedData } from '@/types/csv';
-import { UserSummary } from '@/utils/analytics';
+import type { ProcessedData } from '@/types/csv';
+import type { UserSummary } from '@/utils/analytics';
+import { categorizeUserConsumption, calculateUnusedValue, CONSUMPTION_THRESHOLDS } from '@/utils/analytics/insights';
+import type { UserConsumptionCategory } from '@/utils/analytics/insights';
+import { buildFeatureUtilizationFromArtifacts } from '@/utils/ingestion/analytics';
+import type { FeatureUsageArtifacts } from '@/utils/ingestion/types';
 
 function makeProcessed(row: Partial<ProcessedData>): ProcessedData {
   const timestamp = row.timestamp || new Date('2025-06-01T00:00:00Z');
   const iso = timestamp.toISOString();
   return {
     timestamp: timestamp as Date,
-    user: row.user || 'u',
+    user: row.user || 'test-user-default',
     model: row.model || 'o3-mini',
     requestsUsed: row.requestsUsed ?? 0,
     exceedsQuota: row.exceedsQuota ?? false,
@@ -25,14 +28,48 @@ function makeProcessed(row: Partial<ProcessedData>): ProcessedData {
   } as ProcessedData;
 }
 
+function makeFeatureUsageArtifacts({
+  codeReview = 0,
+  codingAgent = 0,
+  spark = 0,
+  nonCopilotCodeReview = 0,
+  codeReviewUsers = [],
+  codingAgentUsers = [],
+  sparkUsers = []
+}: {
+  codeReview?: number;
+  codingAgent?: number;
+  spark?: number;
+  nonCopilotCodeReview?: number;
+  codeReviewUsers?: string[];
+  codingAgentUsers?: string[];
+  sparkUsers?: string[];
+}): FeatureUsageArtifacts {
+  return {
+    featureTotals: {
+      codeReview,
+      codingAgent,
+      spark
+    },
+    featureUsers: {
+      codeReview: new Set(codeReviewUsers),
+      codingAgent: new Set(codingAgentUsers),
+      spark: new Set(sparkUsers)
+    },
+    specialTotals: {
+      nonCopilotCodeReview
+    }
+  };
+}
+
 describe('insights analytics', () => {
   test('categorizeUserConsumption threshold boundaries', () => {
     const quota = 300;
     const users: UserSummary[] = [
-      { user: 'lowEdgeBelow', totalRequests: (CONSUMPTION_THRESHOLDS.averageMinPct - 0.1) / 100 * quota, modelBreakdown: {} },
-      { user: 'avgEdge', totalRequests: (CONSUMPTION_THRESHOLDS.averageMinPct) / 100 * quota, modelBreakdown: {} },
-      { user: 'avgHigh', totalRequests: (CONSUMPTION_THRESHOLDS.powerMinPct - 0.1) / 100 * quota, modelBreakdown: {} },
-      { user: 'powerEdge', totalRequests: (CONSUMPTION_THRESHOLDS.powerMinPct) / 100 * quota, modelBreakdown: {} }
+      { user: 'test-user-low-edge-below', totalRequests: (CONSUMPTION_THRESHOLDS.averageMinPct - 0.1) / 100 * quota, modelBreakdown: {} },
+      { user: 'test-user-average-edge', totalRequests: (CONSUMPTION_THRESHOLDS.averageMinPct) / 100 * quota, modelBreakdown: {} },
+      { user: 'test-user-average-high', totalRequests: (CONSUMPTION_THRESHOLDS.powerMinPct - 0.1) / 100 * quota, modelBreakdown: {} },
+      { user: 'test-user-power-edge', totalRequests: (CONSUMPTION_THRESHOLDS.powerMinPct) / 100 * quota, modelBreakdown: {} }
     ];
     const processed: ProcessedData[] = users.map(u => makeProcessed({ user: u.user, quotaValue: quota }));
     const categorized = categorizeUserConsumption(users, processed);
@@ -41,35 +78,34 @@ describe('insights analytics', () => {
       ...categorized.averageUsers.map(u => [u.user, u.category]),
       ...categorized.powerUsers.map(u => [u.user, u.category])
     ]);
-    expect(byUser.lowEdgeBelow).toBe('low');
-    expect(byUser.avgEdge).toBe('average');
-    expect(byUser.avgHigh).toBe('average');
-    expect(byUser.powerEdge).toBe('power');
+    expect(byUser['test-user-low-edge-below']).toBe('low');
+    expect(byUser['test-user-average-edge']).toBe('average');
+    expect(byUser['test-user-average-high']).toBe('average');
+    expect(byUser['test-user-power-edge']).toBe('power');
   });
 
   test('calculateUnusedValue sums unused correctly', () => {
     const users: UserConsumptionCategory[] = [
-      { user: 'a', totalRequests: 100, quota: 300, consumptionPercentage: 33.33, category: 'low' },
-      { user: 'b', totalRequests: 250, quota: 300, consumptionPercentage: 83.33, category: 'average' },
-      { user: 'c', totalRequests: 500, quota: 'unlimited', consumptionPercentage: 0, category: 'low' }
+      { user: 'test-user-one', totalRequests: 100, quota: 300, consumptionPercentage: 33.33, category: 'low' },
+      { user: 'test-user-two', totalRequests: 250, quota: 300, consumptionPercentage: 83.33, category: 'average' },
+      { user: 'test-user-three', totalRequests: 500, quota: 'unlimited', consumptionPercentage: 0, category: 'low' }
     ];
     const total = calculateUnusedValue(users);
     // unused: a=200, b=50 => 250 * overage rate (import pricing constant to avoid magic number).
     expect(total).toBeCloseTo((200 + 50) * PRICING.OVERAGE_RATE_PER_REQUEST, 6);
   });
 
-  test('feature utilization counts sessions & users', () => {
-    const data: ProcessedData[] = [
-      makeProcessed({ user: 'u1', model: 'Code Review', requestsUsed: 3 }),
-      makeProcessed({ user: 'u2', model: 'code review', requestsUsed: 2 }),
-      makeProcessed({ user: '', model: 'Code Review', requestsUsed: 4, quotaValue: 0, totalQuota: '0', isNonCopilotUsage: true, usageBucket: 'non_copilot_code_review' }),
-      makeProcessed({ user: 'u1', model: 'Coding Agent', requestsUsed: 5 }),
-      makeProcessed({ user: 'u3', model: 'Padawan', requestsUsed: 4 }),
-      makeProcessed({ user: 'u2', model: 'gpt-4.1', product: 'spark', sku: 'spark_premium_request', requestsUsed: 7 }),
-      makeProcessed({ user: 'u4', model: 'o3-mini', product: 'spark', sku: 'spark_premium_request', requestsUsed: 1 }),
-      makeProcessed({ user: 'u5', model: 'Spark Helper', requestsUsed: 9 }),
-    ];
-    const stats = calculateFeatureUtilization(data);
+  test('feature utilization counts sessions & users from artifacts', () => {
+    const stats = buildFeatureUtilizationFromArtifacts(makeFeatureUsageArtifacts({
+      codeReview: 9,
+      codingAgent: 9,
+      spark: 8,
+      nonCopilotCodeReview: 4,
+      codeReviewUsers: ['test-user-one', 'test-user-two'],
+      codingAgentUsers: ['test-user-one', 'test-user-three'],
+      sparkUsers: ['test-user-two', 'test-user-four']
+    }));
+
     expect(stats.codeReview.totalSessions).toBe(5);
     expect(stats.codeReview.userCount).toBe(2);
     expect(stats.nonCopilotCodeReview.totalSessions).toBe(4);
@@ -79,14 +115,11 @@ describe('insights analytics', () => {
     expect(stats.spark.userCount).toBe(2);
   });
 
-  test('feature utilization identifies spark from product or sku metadata', () => {
-    const data: ProcessedData[] = [
-      makeProcessed({ user: 'u1', model: 'gpt-4.1', product: 'spark', requestsUsed: 3 }),
-      makeProcessed({ user: 'u2', model: 'o3-mini', sku: 'spark_premium_request', requestsUsed: 2 }),
-      makeProcessed({ user: 'u3', model: 'Spark Helper', product: 'copilot', sku: 'copilot_premium_request', requestsUsed: 5 }),
-    ];
-
-    const stats = calculateFeatureUtilization(data);
+  test('feature utilization uses spark totals and users from artifacts', () => {
+    const stats = buildFeatureUtilizationFromArtifacts(makeFeatureUsageArtifacts({
+      spark: 5,
+      sparkUsers: ['test-user-one', 'test-user-two']
+    }));
 
     expect(stats.spark.totalSessions).toBe(5);
     expect(stats.spark.userCount).toBe(2);

--- a/src/components/DataAnalysis.tsx
+++ b/src/components/DataAnalysis.tsx
@@ -136,6 +136,7 @@ function DataAnalysisInner() {
     filename,
     quotaArtifacts,
     usageArtifacts,
+    featureUsageArtifacts,
     billingArtifacts
   } = useAnalysisContext();
 
@@ -382,6 +383,7 @@ function DataAnalysisInner() {
             <InsightsOverview
               userData={userData}
               processedData={processedData}
+              featureUsageArtifacts={featureUsageArtifacts}
             />
           ) : view === 'costOptimization' ? (
             <CostOptimizationInsights />

--- a/src/components/InsightsOverview.tsx
+++ b/src/components/InsightsOverview.tsx
@@ -5,7 +5,7 @@ import React, { useMemo, useState } from 'react';
 import { AnalysisContext } from '@/context/AnalysisContext';
 import { ProcessedData } from '@/types/csv';
 import { UserSummary } from '@/utils/analytics';
-import { categorizeUserConsumption, calculateFeatureUtilization, calculateUnusedValue, CONSUMPTION_THRESHOLDS } from '@/utils/analytics/insights';
+import { categorizeUserConsumption, calculateUnusedValue, CONSUMPTION_THRESHOLDS } from '@/utils/analytics/insights';
 import { QuotaArtifacts, UsageArtifacts, FeatureUsageArtifacts } from '@/utils/ingestion/types';
 import { buildConsumptionCategoriesFromArtifacts, buildFeatureUtilizationFromArtifacts } from '@/utils/ingestion/analytics';
 import type { WeeklyQuotaExhaustionBreakdown } from '@/utils/ingestion/analytics';
@@ -20,7 +20,7 @@ interface InsightsOverviewProps {
   processedData: ProcessedData[]; // transitional
   quotaArtifacts?: QuotaArtifacts;
   usageArtifacts?: UsageArtifacts;
-  featureUsageArtifacts?: FeatureUsageArtifacts;
+  featureUsageArtifacts: FeatureUsageArtifacts;
   weeklyExhaustionArtifacts?: WeeklyQuotaExhaustionBreakdown;
 }
 
@@ -37,13 +37,10 @@ export function InsightsOverview({ userData, processedData, quotaArtifacts, usag
   const quotaArtifactsFromCtx = analysisCtx?.quotaArtifacts as QuotaArtifacts | undefined;
   const usageArtifactsFromCtx = analysisCtx?.usageArtifacts as UsageArtifacts | undefined;
   const weeklyExhaustionArtifactsFromCtx = analysisCtx?.weeklyExhaustion as WeeklyQuotaExhaustionBreakdown | undefined;
-  const featureUsageArtifactsFromCtx = analysisCtx?.featureUsageArtifacts as FeatureUsageArtifacts | undefined;
-  const aggregateProcessedDataFromCtx = analysisCtx?.aggregateProcessedData;
 
   // Prefer explicitly passed artifacts (future-proof for isolated component tests) then context.
   const quotaArtifactsEff = quotaArtifacts || quotaArtifactsFromCtx;
   const usageArtifactsEff = usageArtifacts || usageArtifactsFromCtx;
-  const featureUsageArtifactsEff = featureUsageArtifacts || featureUsageArtifactsFromCtx;
   const weeklyExhaustionArtifactsEff = weeklyExhaustionArtifacts || weeklyExhaustionArtifactsFromCtx || EMPTY_WEEKLY_EXHAUSTION;
   
   const insightsData = useMemo(() => {
@@ -54,11 +51,8 @@ export function InsightsOverview({ userData, processedData, quotaArtifacts, usag
   }, [userData, processedData, usageArtifactsEff, quotaArtifactsEff]);
 
   const featureUtilization = useMemo(() => {
-    if (featureUsageArtifactsEff) {
-      return buildFeatureUtilizationFromArtifacts(featureUsageArtifactsEff);
-    }
-    return calculateFeatureUtilization(aggregateProcessedDataFromCtx ?? processedData);
-  }, [aggregateProcessedDataFromCtx, processedData, featureUsageArtifactsEff]);
+    return buildFeatureUtilizationFromArtifacts(featureUsageArtifacts);
+  }, [featureUsageArtifacts]);
 
   // Compute unutilized value (only for users with numeric quotas)
   const averageUnusedValueUSD = useMemo(() => calculateUnusedValue(insightsData.averageUsers), [insightsData]);

--- a/src/context/AnalysisContext.tsx
+++ b/src/context/AnalysisContext.tsx
@@ -37,7 +37,7 @@ interface AnalysisContextValue {
   quotaArtifacts: QuotaArtifacts;
   usageArtifacts: UsageArtifacts;
   dailyBucketsArtifacts: DailyBucketsArtifacts;
-  featureUsageArtifacts?: FeatureUsageArtifacts; // optional until fully adopted
+  featureUsageArtifacts: FeatureUsageArtifacts;
   billingArtifacts?: BillingArtifacts; // new billing summary artifacts
   
   // Raw & processed (adapter bridge - to be phased out)
@@ -73,6 +73,39 @@ interface AnalysisContextValue {
   onReset: () => void;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isFeatureUsageArtifacts(value: unknown): value is FeatureUsageArtifacts {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const { featureTotals, featureUsers, specialTotals } = value;
+
+  return (
+    isRecord(featureTotals) &&
+    typeof featureTotals.codeReview === 'number' &&
+    typeof featureTotals.codingAgent === 'number' &&
+    typeof featureTotals.spark === 'number' &&
+    isRecord(featureUsers) &&
+    featureUsers.codeReview instanceof Set &&
+    featureUsers.codingAgent instanceof Set &&
+    featureUsers.spark instanceof Set &&
+    isRecord(specialTotals) &&
+    typeof specialTotals.nonCopilotCodeReview === 'number'
+  );
+}
+
+function requireFeatureUsageArtifacts(value: unknown): FeatureUsageArtifacts {
+  if (!isFeatureUsageArtifacts(value)) {
+    throw new Error('Missing or invalid featureUsage output in ingestion result');
+  }
+
+  return value;
+}
+
 // Exporting the raw context as well (in addition to hook) enables optional consumption
 // in components that want to gracefully fallback when provider is absent in tests.
 export const AnalysisContext = createContext<AnalysisContextValue | null>(null);
@@ -82,12 +115,12 @@ export function AnalysisProvider({ ingestionResult, filename, onReset, children 
   const [view, setView] = useState<ViewType>('overview');
 
   // Extract aggregator outputs
-  const { quotaArtifacts, usageArtifacts, dailyBucketsArtifacts, billingArtifacts } = useMemo(() => {
+  const { quotaArtifacts, usageArtifacts, dailyBucketsArtifacts, featureUsageArtifacts, billingArtifacts } = useMemo(() => {
     return {
       quotaArtifacts: ingestionResult.outputs.quota as QuotaArtifacts,
       usageArtifacts: ingestionResult.outputs.usage as UsageArtifacts,
       dailyBucketsArtifacts: ingestionResult.outputs.dailyBuckets as DailyBucketsArtifacts,
-      featureUsageArtifacts: ingestionResult.outputs.featureUsage as FeatureUsageArtifacts | undefined,
+      featureUsageArtifacts: requireFeatureUsageArtifacts(ingestionResult.outputs.featureUsage),
       billingArtifacts: ingestionResult.outputs.billing as BillingArtifacts | undefined
     };
   }, [ingestionResult]);
@@ -152,7 +185,7 @@ export function AnalysisProvider({ ingestionResult, filename, onReset, children 
     quotaArtifacts,
     usageArtifacts,
     dailyBucketsArtifacts,
-    featureUsageArtifacts: ingestionResult.outputs.featureUsage as FeatureUsageArtifacts | undefined,
+    featureUsageArtifacts,
     billingArtifacts: billingArtifacts,
     // Legacy adapter bridge
     baseProcessed,

--- a/src/utils/analytics/insights.ts
+++ b/src/utils/analytics/insights.ts
@@ -1,7 +1,6 @@
 import { PRICING } from '@/constants/pricing';
 import type { ProcessedData } from '@/types/csv';
 import { buildUserQuotaMapFromRows } from '@/utils/analytics/quota';
-import { isCodeReviewModel, isCodingAgentModel, isSparkProduct } from '@/utils/productClassification';
 
 import type { UserSummary } from './types';
 
@@ -30,41 +29,6 @@ export const CONSUMPTION_THRESHOLDS = Object.freeze({
   powerMinPct: 90,
   averageMinPct: 45
 });
-
-export function calculateFeatureUtilization(processedData: ProcessedData[]): FeatureUtilizationStats {
-  const codeReviewUsers = new Map<string, number>();
-  const codingAgentUsers = new Map<string, number>();
-  const sparkUsers = new Map<string, number>();
-  let totalCodeReviewSessions = 0;
-  let totalCodingAgentSessions = 0;
-  let totalSparkSessions = 0;
-  let totalNonCopilotCodeReviewSessions = 0;
-  processedData.forEach(row => {
-    if (isCodeReviewModel(row.model)) {
-      if (row.isNonCopilotUsage) {
-        totalNonCopilotCodeReviewSessions += row.requestsUsed;
-      } else {
-        totalCodeReviewSessions += row.requestsUsed;
-        codeReviewUsers.set(row.user, (codeReviewUsers.get(row.user) || 0) + row.requestsUsed);
-      }
-    }
-    if (isCodingAgentModel(row.model)) {
-      totalCodingAgentSessions += row.requestsUsed;
-      codingAgentUsers.set(row.user, (codingAgentUsers.get(row.user) || 0) + row.requestsUsed);
-    }
-    if (isSparkProduct(row.product, row.sku)) {
-      totalSparkSessions += row.requestsUsed;
-      sparkUsers.set(row.user, (sparkUsers.get(row.user) || 0) + row.requestsUsed);
-    }
-  });
-  const avg = (total: number, count: number) => (count > 0 ? total / count : 0);
-  return {
-    codeReview: { totalSessions: totalCodeReviewSessions, averagePerUser: avg(totalCodeReviewSessions, codeReviewUsers.size), userCount: codeReviewUsers.size },
-    codingAgent: { totalSessions: totalCodingAgentSessions, averagePerUser: avg(totalCodingAgentSessions, codingAgentUsers.size), userCount: codingAgentUsers.size },
-    spark: { totalSessions: totalSparkSessions, averagePerUser: avg(totalSparkSessions, sparkUsers.size), userCount: sparkUsers.size },
-    nonCopilotCodeReview: { totalSessions: totalNonCopilotCodeReviewSessions }
-  };
-}
 
 export function categorizeUserConsumption(userData: UserSummary[], processedData: ProcessedData[]): InsightsOverviewData {
   const userQuotaMap = buildUserQuotaMapFromRows(processedData);

--- a/src/utils/ingestion/FeatureUsageAggregator.ts
+++ b/src/utils/ingestion/FeatureUsageAggregator.ts
@@ -10,8 +10,7 @@
  *  - featureTotals: total request quantities per feature
  *  - featureUsers: distinct user sets per feature
  *
- * This replaces on-render O(R) scans (e.g. calculateFeatureUtilization)
- * with incremental O(1) updates during ingestion.
+ * This replaces on-render O(R) scans with incremental O(1) updates during ingestion.
  */
 import { Aggregator, AggregatorContext, NormalizedRow, FeatureUsageArtifacts } from './types';
 import { isCodeReviewModel, isCodingAgentModel, isSparkProduct } from '@/utils/productClassification';

--- a/src/utils/ingestion/analytics.ts
+++ b/src/utils/ingestion/analytics.ts
@@ -450,8 +450,7 @@ export function buildDailyModelUsageFromArtifacts(
 // Feature Utilization From FeatureUsageArtifacts
 // -----------------------------
 /**
- * Build FeatureUtilizationStats (matching legacy calculateFeatureUtilization return shape)
- * directly from FeatureUsageAggregator artifacts.
+ * Build FeatureUtilizationStats directly from FeatureUsageAggregator artifacts.
  */
 export function buildFeatureUtilizationFromArtifacts(featureUsage: FeatureUsageArtifacts): FeatureUtilizationStats {
   const { featureTotals, featureUsers, specialTotals } = featureUsage;


### PR DESCRIPTION
`InsightsOverview` duplicated feature utilization accumulation by falling back to a render-time processed-data scan even though ingestion already produces `FeatureUsageArtifacts`. This PR removes that duplicate path so `FeatureUsageAggregator` and `buildFeatureUtilizationFromArtifacts` stay the single source of truth.

## Summary

| Commit | Change |
|--------|--------|
| `refactor: use feature usage artifacts for insights` | Removes the legacy `calculateFeatureUtilization` fallback, requires feature usage artifacts for insights, validates the ingestion output before exposing it through context, and migrates tests to artifact-based fixtures. |

## Notes

- `featureUsageArtifacts` is now required for `InsightsOverview`, matching the production ingestion flow.
- `AnalysisContext` validates the `featureUsage` output shape before consumers use it, addressing the review concern from the prior closed attempt in #97.
- Existing billing/component test fixtures now include empty feature usage artifacts where the feature data is not under test.

## Validation

- `npm run build && npm run lint && npm run test`
- `npm test -- --runInBand __tests__/utils/insights.test.ts __tests__/utils/featureUsageAggregator.test.ts __tests__/components/MissingRawDataAggregator.test.tsx __tests__/components/CodingAgentOverview.test.tsx`

Fixes: #91