### PR TITLE
Centralize billing accumulation

### DIFF
--- a/__tests__/utils/billingAggregator.test.ts
+++ b/__tests__/utils/billingAggregator.test.ts
@@ -1,3 +1,5 @@
+import type { ProcessedData } from '@/types/csv';
+import { buildBillingArtifactsFromProcessedData } from '@/utils/ingestion/billingAccumulator';
 import { BillingAggregator } from '@/utils/ingestion/BillingAggregator';
 import { AggregatorContext, NormalizedRow } from '@/utils/ingestion/types';
 import { PRICING } from '@/constants/pricing';
@@ -13,6 +15,25 @@ describe('BillingAggregator', () => {
       model: 'gpt-test',
       quantity: 1,
       ...partial
+    };
+  }
+
+  function buildProcessedRow(partial: Partial<ProcessedData>): ProcessedData {
+    const timestamp = new Date('2025-07-01T00:00:00Z');
+
+    return {
+      timestamp,
+      user: 'test-user-one',
+      model: 'Code Review',
+      requestsUsed: 1,
+      exceedsQuota: false,
+      totalQuota: '1000',
+      quotaValue: PRICING.ENTERPRISE_QUOTA,
+      iso: timestamp.toISOString(),
+      dateKey: '2025-07-01',
+      monthKey: '2025-07',
+      epoch: timestamp.getTime(),
+      ...partial,
     };
   }
 
@@ -203,5 +224,41 @@ describe('BillingAggregator', () => {
     expect(out.orgTotals.get('test-org-one')?.gross).toBe(5);
     expect(out.costCenterTotals.get('test-cost-center-one')?.net).toBe(5);
     expect(out.billingByModel.get('Code Review')?.quantity).toBe(3);
+  });
+
+  it('builds billing artifacts from filtered processed data', () => {
+    const out = buildBillingArtifactsFromProcessedData([
+      buildProcessedRow({
+        user: 'test-user-one',
+        organization: 'test-org-one',
+        costCenter: 'test-cost-center-one',
+        requestsUsed: 4,
+        grossAmount: 8,
+        netAmount: 8,
+      }),
+      buildProcessedRow({
+        user: '',
+        organization: 'test-org-one',
+        costCenter: 'test-cost-center-one',
+        requestsUsed: 2,
+        grossAmount: 3,
+        netAmount: 3,
+        isNonCopilotUsage: true,
+        usageBucket: 'non_copilot_code_review',
+      }),
+    ]);
+
+    expect(out.userMap.get('test-user-one')?.quantity).toBe(4);
+    expect(out.specialBuckets).toEqual([
+      expect.objectContaining({
+        key: 'non_copilot_code_review',
+        quantity: 2,
+        gross: 3,
+        net: 3,
+      }),
+    ]);
+    expect(out.orgTotals.get('test-org-one')?.quantity).toBe(6);
+    expect(out.costCenterTotals.get('test-cost-center-one')?.quantity).toBe(6);
+    expect(out.billingByModel.get('Code Review')?.quantity).toBe(6);
   });
 });

--- a/__tests__/utils/billingAggregator.test.ts
+++ b/__tests__/utils/billingAggregator.test.ts
@@ -47,6 +47,49 @@ describe('BillingAggregator', () => {
     expect(b.quantity).toBe(1);
   });
 
+  it('tracks grouped billing totals for organizations, cost centers, and models', () => {
+    const agg = new BillingAggregator();
+    agg.init?.(ctx);
+    agg.onRow(buildRow({
+      user: 'test-user-one',
+      model: 'Claude Sonnet 4',
+      organization: 'test-org-one',
+      costCenter: 'test-cost-center-one',
+      grossAmount: 2,
+      discountAmount: 0.5,
+      netAmount: 1.5,
+      aicQuantity: 10,
+      aicGrossAmount: 0.1,
+      quantity: 2,
+    }), ctx);
+    agg.onRow(buildRow({
+      user: 'test-user-two',
+      model: 'Claude Sonnet 4',
+      organization: 'test-org-one',
+      costCenter: 'test-cost-center-two',
+      grossAmount: 3,
+      discountAmount: 1,
+      netAmount: 2,
+      aicQuantity: 20,
+      aicGrossAmount: 0.2,
+      quantity: 3,
+    }), ctx);
+
+    const out = agg.finalize(ctx);
+    const orgTotals = out.orgTotals.get('test-org-one');
+    expect(orgTotals).toMatchObject({
+      gross: 5,
+      discount: 1.5,
+      net: 3.5,
+      aicQuantity: 30,
+      quantity: 5,
+    });
+    expect(orgTotals?.aicGrossAmount).toBeCloseTo(0.3);
+    expect(out.costCenterTotals.get('test-cost-center-one')?.net).toBe(1.5);
+    expect(out.costCenterTotals.get('test-cost-center-two')?.net).toBe(2);
+    expect(out.billingByModel.get('Claude Sonnet 4')?.quantity).toBe(5);
+  });
+
   it('handles absence of billing fields gracefully', () => {
     const agg = new BillingAggregator();
     agg.init?.(ctx);
@@ -126,5 +169,39 @@ describe('BillingAggregator', () => {
         quotaValue: 0
       })
     ]);
+  });
+
+  it('includes non-Copilot aggregate rows in grouped billing totals', () => {
+    const agg = new BillingAggregator();
+    agg.init?.(ctx);
+    agg.onRow(buildRow({
+      user: 'test-user-one',
+      model: 'Code Review',
+      organization: 'test-org-one',
+      costCenter: 'test-cost-center-one',
+      quantity: 1,
+      grossAmount: 2,
+      netAmount: 2,
+    }), ctx);
+    agg.onRow(buildRow({
+      user: '',
+      model: 'Code Review',
+      organization: 'test-org-one',
+      costCenter: 'test-cost-center-one',
+      quantity: 2,
+      grossAmount: 3,
+      netAmount: 3,
+      isNonCopilotUsage: true,
+      usageBucket: 'non_copilot_code_review',
+    }), ctx);
+
+    const out = agg.finalize(ctx);
+    expect(out.userMap.get('test-user-one')?.quantity).toBe(1);
+    expect(out.users).toHaveLength(1);
+    expect(out.specialBuckets?.[0]?.quantity).toBe(2);
+    expect(out.orgTotals.get('test-org-one')?.quantity).toBe(3);
+    expect(out.orgTotals.get('test-org-one')?.gross).toBe(5);
+    expect(out.costCenterTotals.get('test-cost-center-one')?.net).toBe(5);
+    expect(out.billingByModel.get('Code Review')?.quantity).toBe(3);
   });
 });

--- a/src/components/CostCentersOverview.tsx
+++ b/src/components/CostCentersOverview.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import React, { useMemo, useState } from 'react';
+
 import { useAnalysisContext } from '@/context/AnalysisContext';
-import { hasAicFields } from '@/utils/aicFields';
 import {
   accumulateProductCost,
   createEmptyProductCostMap,
@@ -21,16 +21,12 @@ interface CostCenterRow {
 }
 
 export function CostCentersOverview() {
-  const { aggregateProcessedData } = useAnalysisContext();
+  const { aggregateProcessedData, billingArtifacts } = useAnalysisContext();
   const [expandedCenter, setExpandedCenter] = useState<string | null>(null);
 
   const costCenterRows = useMemo((): CostCenterRow[] => {
     const map = new Map<string, {
       requests: number;
-      gross: number;
-      discount: number;
-      net: number;
-      aicGrossAmount: number;
       productBuckets: ReturnType<typeof createEmptyProductCostMap>;
     }>();
 
@@ -40,38 +36,34 @@ export function CostCentersOverview() {
       if (!entry) {
         entry = {
           requests: 0,
-          gross: 0,
-          discount: 0,
-          net: 0,
-          aicGrossAmount: 0,
           productBuckets: createEmptyProductCostMap(),
         };
         map.set(cc, entry);
       }
 
       entry.requests += row.requestsUsed;
-      entry.gross += row.grossAmount ?? 0;
-      entry.discount += row.discountAmount ?? 0;
-      entry.net += row.netAmount ?? 0;
-      entry.aicGrossAmount += row.aicGrossAmount ?? 0;
       accumulateProductCost(entry.productBuckets, row);
     }
 
     return Array.from(map.entries())
-      .map(([name, data]) => ({
-        name,
-        requests: data.requests,
-        gross: data.gross,
-        discount: data.discount,
-        net: data.net,
-        aicGrossAmount: data.aicGrossAmount,
-        products: getPopulatedProductCosts(data.productBuckets),
-      }))
+      .map(([name, data]) => {
+        const totals = billingArtifacts?.costCenterTotals.get(name);
+
+        return {
+          name,
+          requests: data.requests,
+          gross: totals?.gross ?? 0,
+          discount: totals?.discount ?? 0,
+          net: totals?.net ?? 0,
+          aicGrossAmount: totals?.aicGrossAmount ?? 0,
+          products: getPopulatedProductCosts(data.productBuckets),
+        };
+      })
       .sort((a, b) => b.net - a.net);
-  }, [aggregateProcessedData]);
+  }, [aggregateProcessedData, billingArtifacts]);
 
   const hasCosts = costCenterRows.some(r => r.gross > 0 || r.net > 0);
-  const hasAicGross = hasAicFields(aggregateProcessedData);
+  const hasAicGross = billingArtifacts?.hasAnyAicData === true;
   const detailColSpan = 2 + (hasAicGross ? 1 : 0) + (hasCosts ? 3 : 0);
 
   return (

--- a/src/components/CostCentersOverview.tsx
+++ b/src/components/CostCentersOverview.tsx
@@ -9,6 +9,7 @@ import {
   getPopulatedProductCosts,
   ProductCost,
 } from '@/utils/productCosts';
+import { UNASSIGNED_BILLING_GROUP } from '@/utils/ingestion';
 
 interface CostCenterRow {
   name: string;
@@ -31,7 +32,7 @@ export function CostCentersOverview() {
     }>();
 
     for (const row of aggregateProcessedData) {
-      const cc = row.costCenter || 'Unassigned';
+      const cc = row.costCenter || UNASSIGNED_BILLING_GROUP;
       let entry = map.get(cc);
       if (!entry) {
         entry = {

--- a/src/components/DataAnalysis.tsx
+++ b/src/components/DataAnalysis.tsx
@@ -5,8 +5,7 @@ import React, { useEffect, useMemo } from 'react';
 import { PRICING } from '@/constants/pricing';
 import { AnalysisProvider, useAnalysisContext } from '@/context/AnalysisContext';
 import { aggregateAutoModeSavings } from '@/utils/autoModeSavings';
-import { hasAicFields } from '@/utils/aicFields';
-import { calculateAicPoolEstimate, calculateIncludedAicCreditsForUsers } from '@/utils/aicPool';
+import { calculateAicPoolEstimate } from '@/utils/aicPool';
 import { getModelColor } from '@/utils/modelColors';
 import { aggregateProductCosts } from '@/utils/productCosts';
 
@@ -170,45 +169,11 @@ function DataAnalysisInner() {
     return items;
   }, [hasCostCenters, hasOrganizations]);
 
-  const processedCosts = useMemo(() => {
-    const hasBillingData = aggregateProcessedData.some(
-      (row) =>
-        row.netAmount !== undefined ||
-        row.grossAmount !== undefined ||
-        row.discountAmount !== undefined
-    );
+  const costMetricsAvailable = billingArtifacts?.hasAnyBillingData === true;
+  const aggregatedCosts = costMetricsAvailable && billingArtifacts ? billingArtifacts.totals : null;
 
-    if (!hasBillingData) {
-      return null;
-    }
-
-    return aggregateProcessedData.reduce((acc, row) => {
-      acc.net += row.netAmount ?? 0;
-      acc.gross += row.grossAmount ?? 0;
-      acc.discount += row.discountAmount ?? 0;
-      return acc;
-    }, { net: 0, gross: 0, discount: 0 });
-  }, [aggregateProcessedData]);
-
-  const costMetricsAvailable = processedCosts !== null || billingArtifacts?.hasAnyBillingData === true;
-  const aggregatedCosts = processedCosts ?? (billingArtifacts?.hasAnyBillingData ? billingArtifacts.totals : null);
-
-  const processedAic = useMemo(() => {
-    const hasAicData = hasAicFields(aggregateProcessedData);
-
-    if (!hasAicData) {
-      return null;
-    }
-
-    return aggregateProcessedData.reduce((acc, row) => {
-      acc.aicQuantity += row.aicQuantity ?? 0;
-      acc.aicGrossAmount += row.aicGrossAmount ?? 0;
-      return acc;
-    }, { aicQuantity: 0, aicGrossAmount: 0 });
-  }, [aggregateProcessedData]);
-
-  const aicMetricsAvailable = processedAic !== null || billingArtifacts?.hasAnyAicData === true;
-  const aggregatedAic = processedAic ?? (
+  const aicMetricsAvailable = billingArtifacts?.hasAnyAicData === true;
+  const aggregatedAic = (
     billingArtifacts?.hasAnyAicData
       ? {
         aicQuantity: billingArtifacts.totals.aicQuantity ?? 0,
@@ -220,33 +185,34 @@ function DataAnalysisInner() {
   );
   const aicPoolEstimate = aggregatedAic
     ? calculateAicPoolEstimate(
-      'aicIncludedCredits' in aggregatedAic
-        ? aggregatedAic.aicIncludedCredits
-        : calculateIncludedAicCreditsForUsers(aggregateProcessedData),
+      aggregatedAic.aicIncludedCredits,
       aggregatedAic.aicGrossAmount
     )
     : null;
 
   const modelRows = useMemo(() => {
-    const map = new Map<string, { model: string; requests: number; gross: number; discount: number; net: number; aicGrossAmount: number }>();
-    for (const row of aggregateProcessedData) {
-      const prev = map.get(row.model) ?? {
-        model: row.model,
-        requests: 0,
-        gross: 0,
-        discount: 0,
-        net: 0,
-        aicGrossAmount: 0,
-      };
-      prev.requests += row.requestsUsed;
-      prev.gross += row.grossAmount ?? 0;
-      prev.discount += row.discountAmount ?? 0;
-      prev.net += row.netAmount ?? 0;
-      prev.aicGrossAmount += row.aicGrossAmount ?? 0;
-      map.set(row.model, prev);
+    if (billingArtifacts) {
+      return Array.from(billingArtifacts.billingByModel.entries())
+        .map(([model, totals]) => ({
+          model,
+          requests: totals.quantity,
+          gross: totals.gross,
+          discount: totals.discount,
+          net: totals.net,
+          aicGrossAmount: totals.aicGrossAmount,
+        }))
+        .sort((left, right) => right.requests - left.requests);
     }
-    return Array.from(map.values()).sort((left, right) => right.requests - left.requests);
-  }, [aggregateProcessedData]);
+
+    return analysis.requestsByModel.map((row) => ({
+      model: row.model,
+      requests: row.totalRequests,
+      gross: 0,
+      discount: 0,
+      net: 0,
+      aicGrossAmount: 0,
+    }));
+  }, [analysis.requestsByModel, billingArtifacts]);
 
   const hasModelCosts = modelRows.some(
     (row) => row.gross > 0 || row.discount > 0 || row.net > 0
@@ -367,6 +333,7 @@ function DataAnalysisInner() {
               dailyCumulativeData={dailyCumulativeData}
               quotaArtifacts={quotaArtifacts}
               usageArtifacts={usageArtifacts}
+              billingArtifacts={billingArtifacts}
             />
           ) : view === 'costCenters' ? (
             <CostCentersOverview />

--- a/src/components/OrganizationsOverview.tsx
+++ b/src/components/OrganizationsOverview.tsx
@@ -9,6 +9,7 @@ import {
   getPopulatedProductCosts,
   ProductCost,
 } from '@/utils/productCosts';
+import { UNASSIGNED_BILLING_GROUP } from '@/utils/ingestion';
 
 interface OrganizationRow {
   name: string;
@@ -33,7 +34,7 @@ export function OrganizationsOverview() {
     }>();
 
     for (const row of aggregateProcessedData) {
-      const org = row.organization || 'Unassigned';
+      const org = row.organization || UNASSIGNED_BILLING_GROUP;
       let entry = map.get(org);
       if (!entry) {
         entry = {

--- a/src/components/OrganizationsOverview.tsx
+++ b/src/components/OrganizationsOverview.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import React, { useMemo, useState } from 'react';
+
 import { useAnalysisContext } from '@/context/AnalysisContext';
-import { hasAicFields } from '@/utils/aicFields';
 import {
   accumulateProductCost,
   createEmptyProductCostMap,
@@ -22,17 +22,13 @@ interface OrganizationRow {
 }
 
 export function OrganizationsOverview() {
-  const { aggregateProcessedData } = useAnalysisContext();
+  const { aggregateProcessedData, billingArtifacts } = useAnalysisContext();
   const [expandedOrg, setExpandedOrg] = useState<string | null>(null);
 
   const orgRows = useMemo((): OrganizationRow[] => {
     const map = new Map<string, {
       userSet: Set<string>;
       requests: number;
-      gross: number;
-      discount: number;
-      net: number;
-      aicGrossAmount: number;
       productBuckets: ReturnType<typeof createEmptyProductCostMap>;
     }>();
 
@@ -43,10 +39,6 @@ export function OrganizationsOverview() {
         entry = {
           userSet: new Set(),
           requests: 0,
-          gross: 0,
-          discount: 0,
-          net: 0,
-          aicGrossAmount: 0,
           productBuckets: createEmptyProductCostMap(),
         };
         map.set(org, entry);
@@ -56,29 +48,29 @@ export function OrganizationsOverview() {
         entry.userSet.add(row.user);
       }
       entry.requests += row.requestsUsed;
-      entry.gross += row.grossAmount ?? 0;
-      entry.discount += row.discountAmount ?? 0;
-      entry.net += row.netAmount ?? 0;
-      entry.aicGrossAmount += row.aicGrossAmount ?? 0;
       accumulateProductCost(entry.productBuckets, row);
     }
 
     return Array.from(map.entries())
-      .map(([name, data]) => ({
-        name,
-        users: data.userSet.size,
-        requests: data.requests,
-        gross: data.gross,
-        discount: data.discount,
-        net: data.net,
-        aicGrossAmount: data.aicGrossAmount,
-        products: getPopulatedProductCosts(data.productBuckets),
-      }))
+      .map(([name, data]) => {
+        const totals = billingArtifacts?.orgTotals.get(name);
+
+        return {
+          name,
+          users: data.userSet.size,
+          requests: data.requests,
+          gross: totals?.gross ?? 0,
+          discount: totals?.discount ?? 0,
+          net: totals?.net ?? 0,
+          aicGrossAmount: totals?.aicGrossAmount ?? 0,
+          products: getPopulatedProductCosts(data.productBuckets),
+        };
+      })
       .sort((a, b) => b.net - a.net);
-  }, [aggregateProcessedData]);
+  }, [aggregateProcessedData, billingArtifacts]);
 
   const hasCosts = orgRows.some(r => r.gross > 0 || r.net > 0);
-  const hasAicGross = hasAicFields(aggregateProcessedData);
+  const hasAicGross = billingArtifacts?.hasAnyAicData === true;
   const detailColSpan = 3 + (hasAicGross ? 1 : 0) + (hasCosts ? 3 : 0);
 
   return (

--- a/src/components/UsersOverview.tsx
+++ b/src/components/UsersOverview.tsx
@@ -51,10 +51,15 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, qu
 
   const userCosts = effectiveBillingArtifacts.userMap;
 
-  const hasCosts = useMemo(() =>
-    Array.from(userCosts.values()).some(r => (r.gross ?? 0) > 0 || (r.net ?? 0) > 0),
-    [userCosts]
-  );
+  const hasCosts = useMemo(() => {
+    for (const costs of userCosts.values()) {
+      if ((costs.gross ?? 0) > 0 || (costs.net ?? 0) > 0) {
+        return true;
+      }
+    }
+
+    return false;
+  }, [userCosts]);
 
   const hasAicGross = effectiveBillingArtifacts.hasAnyAicData;
 

--- a/src/components/UsersOverview.tsx
+++ b/src/components/UsersOverview.tsx
@@ -1,15 +1,23 @@
 'use client';
 
 import { useState, useMemo, useCallback } from 'react';
-import { UsersConsumptionHeatmap } from './charts/UsersConsumptionHeatmap';
-import { ProcessedData } from '@/types/csv';
-import { UserDetailsView } from './UserDetailsView';
-import { useSortableTable } from '@/hooks/useSortableTable';
-import { useIsMobile } from '@/hooks/useIsMobile';
+
 import { PRICING } from '@/constants/pricing';
-import { hasAicFields } from '@/utils/aicFields';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import { useSortableTable } from '@/hooks/useSortableTable';
+import { ProcessedData } from '@/types/csv';
 import type { UserSummary } from '@/utils/analytics';
-import { getUserQuota, QuotaArtifacts, UsageArtifacts, computeOverageSummaryFromProcessedData } from '@/utils/ingestion';
+import {
+  BillingArtifacts,
+  buildBillingArtifactsFromProcessedData,
+  computeOverageSummaryFromProcessedData,
+  getUserQuota,
+  QuotaArtifacts,
+  UsageArtifacts,
+} from '@/utils/ingestion';
+
+import { UsersConsumptionHeatmap } from './charts/UsersConsumptionHeatmap';
+import { UserDetailsView } from './UserDetailsView';
 
 type DailyCumulativeData = { date: string; [user: string]: string | number };
 const ALL_FILTERS_VALUE = '__all__';
@@ -20,9 +28,10 @@ interface UsersOverviewProps {
   dailyCumulativeData: DailyCumulativeData[];
   quotaArtifacts: QuotaArtifacts;
   usageArtifacts: UsageArtifacts;
+  billingArtifacts?: BillingArtifacts;
 }
 
-export function UsersOverview({ userData, processedData, dailyCumulativeData, quotaArtifacts, usageArtifacts }: UsersOverviewProps) {
+export function UsersOverview({ userData, processedData, dailyCumulativeData, quotaArtifacts, usageArtifacts, billingArtifacts }: UsersOverviewProps) {
   const [showChart, setShowChart] = useState(true);
   const [currentPage, setCurrentPage] = useState(0);
   const [selectedOrganization, setSelectedOrganization] = useState(ALL_FILTERS_VALUE);
@@ -36,28 +45,18 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, qu
 
   type ColumnKey = 'quota' | 'totalRequests' | 'aicGrossAmount' | 'gross' | 'discount' | 'net';
 
-  const userCosts = useMemo(() => {
-    const map = new Map<string, { gross: number; discount: number; net: number; aicGrossAmount: number }>();
-    for (const row of processedData) {
-      const prev = map.get(row.user) ?? { gross: 0, discount: 0, net: 0, aicGrossAmount: 0 };
-      prev.gross += row.grossAmount ?? 0;
-      prev.discount += row.discountAmount ?? 0;
-      prev.net += row.netAmount ?? 0;
-      prev.aicGrossAmount += row.aicGrossAmount ?? 0;
-      map.set(row.user, prev);
-    }
-    return map;
-  }, [processedData]);
+  const effectiveBillingArtifacts = useMemo(() => (
+    billingArtifacts ?? buildBillingArtifactsFromProcessedData(processedData)
+  ), [billingArtifacts, processedData]);
+
+  const userCosts = effectiveBillingArtifacts.userMap;
 
   const hasCosts = useMemo(() =>
-    processedData.some(r => (r.grossAmount ?? 0) > 0 || (r.netAmount ?? 0) > 0),
-    [processedData]
+    Array.from(userCosts.values()).some(r => (r.gross ?? 0) > 0 || (r.net ?? 0) > 0),
+    [userCosts]
   );
 
-  const hasAicGross = useMemo(() =>
-    hasAicFields(processedData),
-    [processedData]
-  );
+  const hasAicGross = effectiveBillingArtifacts.hasAnyAicData;
 
   const columns = useMemo<ColumnKey[]>(() => [
     'quota',
@@ -74,8 +73,7 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, qu
 
     if (column === 'totalRequests') return row.totalRequests;
     if (column === 'gross' || column === 'discount' || column === 'net' || column === 'aicGrossAmount') {
-      const costs = userCosts.get(row.user) ?? { gross: 0, discount: 0, net: 0, aicGrossAmount: 0 };
-      return costs[column];
+      return userCosts.get(row.user)?.[column] ?? 0;
     }
     return 0;
   }, [quotaArtifacts, userCosts]);
@@ -397,7 +395,7 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, qu
                 const userQuota = getUserQuota(quotaArtifacts, user.user);
                 const isOverQuota = userQuota !== 'unlimited' && user.totalRequests > userQuota;
                 const quotaDisplay = userQuota === 'unlimited' ? 'Unlimited' : `${userQuota}`;
-                const costs = userCosts.get(user.user) ?? { gross: 0, discount: 0, net: 0, aicGrossAmount: 0 };
+                const costs = userCosts.get(user.user);
 
                 return (
                 <button
@@ -421,16 +419,16 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, qu
                       </span>
                     )}
                   </div>
-                  {hasCosts && (costs.gross > 0 || costs.discount > 0 || costs.net > 0) && (
+                  {hasCosts && ((costs?.gross ?? 0) > 0 || (costs?.discount ?? 0) > 0 || (costs?.net ?? 0) > 0) && (
                     <div className="flex items-center gap-3 mt-1.5 text-xs font-mono tabular-nums">
-                      <span className="text-[#636c76]">${costs.gross.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
-                      <span className="text-emerald-600">-${costs.discount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
-                      <span className="font-semibold text-[#1f2328]">${costs.net.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+                      <span className="text-[#636c76]">${(costs?.gross ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+                      <span className="text-emerald-600">-${(costs?.discount ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+                      <span className="font-semibold text-[#1f2328]">${(costs?.net ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
                     </div>
                   )}
                   {hasAicGross && (
                     <div className="mt-1.5 text-xs font-mono tabular-nums text-[#636c76]">
-                      AI Credits Gross: ${costs.aicGrossAmount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                      AI Credits Gross: ${(costs?.aicGrossAmount ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                     </div>
                   )}
                 </button>
@@ -586,24 +584,24 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, qu
                     )}
                   </td>
                   {(() => {
-                    const costs = userCosts.get(user.user) ?? { gross: 0, discount: 0, net: 0, aicGrossAmount: 0 };
+                    const costs = userCosts.get(user.user);
                     return (
                       <>
                         {hasAicGross && (
                           <td className="px-4 py-3 whitespace-nowrap text-sm text-[#636c76] font-mono tabular-nums text-right">
-                            ${costs.aicGrossAmount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                            ${(costs?.aicGrossAmount ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                           </td>
                         )}
                         {hasCosts && (
                           <>
                             <td className="px-4 py-3 whitespace-nowrap text-sm text-[#636c76] font-mono tabular-nums text-right">
-                              ${costs.gross.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                              ${(costs?.gross ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                             </td>
                             <td className="px-4 py-3 whitespace-nowrap text-sm text-emerald-600 font-mono tabular-nums text-right">
-                              -${costs.discount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                              -${(costs?.discount ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                             </td>
                             <td className="px-4 py-3 whitespace-nowrap text-sm font-semibold text-[#1f2328] font-mono tabular-nums text-right">
-                              ${costs.net.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                              ${(costs?.net ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                             </td>
                           </>
                         )}

--- a/src/context/AnalysisContext.tsx
+++ b/src/context/AnalysisContext.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import React, { createContext, useContext, useMemo, useState, ReactNode } from 'react';
-import { ProcessedData } from '@/types/csv';
+
+import { PRICING } from '@/constants/pricing';
 import { useAnalysisFilters } from '@/hooks/useAnalysisFilters';
 import { useAnalyzedData } from '@/hooks/useAnalyzedData';
-import { PRICING } from '@/constants/pricing';
+import { ProcessedData } from '@/types/csv';
 import { 
   IngestionResult, 
   QuotaArtifacts, 
@@ -13,6 +14,7 @@ import {
   FeatureUsageArtifacts,
   BillingArtifacts,
   NormalizedRow,
+  buildBillingArtifactsFromProcessedData,
   buildProcessedDataFromRows
 } from '@/utils/ingestion';
 
@@ -106,6 +108,22 @@ function requireFeatureUsageArtifacts(value: unknown): FeatureUsageArtifacts {
   return value;
 }
 
+function withBillingArtifactDefaults(value: BillingArtifacts | undefined): BillingArtifacts | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  return {
+    ...value,
+    users: value.users ?? [],
+    userMap: value.userMap ?? new Map(),
+    orgTotals: value.orgTotals ?? new Map(),
+    costCenterTotals: value.costCenterTotals ?? new Map(),
+    billingByModel: value.billingByModel ?? new Map(),
+    specialBuckets: value.specialBuckets ?? [],
+  };
+}
+
 // Exporting the raw context as well (in addition to hook) enables optional consumption
 // in components that want to gracefully fallback when provider is absent in tests.
 export const AnalysisContext = createContext<AnalysisContextValue | null>(null);
@@ -121,7 +139,7 @@ export function AnalysisProvider({ ingestionResult, filename, onReset, children 
       usageArtifacts: ingestionResult.outputs.usage as UsageArtifacts,
       dailyBucketsArtifacts: ingestionResult.outputs.dailyBuckets as DailyBucketsArtifacts,
       featureUsageArtifacts: requireFeatureUsageArtifacts(ingestionResult.outputs.featureUsage),
-      billingArtifacts: ingestionResult.outputs.billing as BillingArtifacts | undefined
+      billingArtifacts: withBillingArtifactDefaults(ingestionResult.outputs.billing as BillingArtifacts | undefined)
     };
   }, [ingestionResult]);
 
@@ -156,6 +174,12 @@ export function AnalysisProvider({ ingestionResult, filename, onReset, children 
     dailyBucketsArtifacts
   });
 
+  const effectiveBillingArtifacts = useMemo(() => (
+    baseProcessed.length > 0
+      ? buildBillingArtifactsFromProcessedData(aggregateProcessedData)
+      : billingArtifacts
+  ), [aggregateProcessedData, baseProcessed.length, billingArtifacts]);
+
   // Use the suggested plan from data (auto-derived from report content)
   const selectedPlan = analysis.quotaBreakdown.suggestedPlan ?? 'business';
 
@@ -186,7 +210,7 @@ export function AnalysisProvider({ ingestionResult, filename, onReset, children 
     usageArtifacts,
     dailyBucketsArtifacts,
     featureUsageArtifacts,
-    billingArtifacts: billingArtifacts,
+    billingArtifacts: effectiveBillingArtifacts,
     // Legacy adapter bridge
     baseProcessed,
     processedData,

--- a/src/utils/ingestion/BillingAggregator.ts
+++ b/src/utils/ingestion/BillingAggregator.ts
@@ -1,14 +1,8 @@
 /**
  * BillingAggregator
  * ---------------------------------
- * Streams normalized rows and accumulates billing-related numeric fields:
- *  - grossAmount
- *  - discountAmount
- *  - netAmount
- *  - aicQuantity
- *  - aicGrossAmount
- * Also tracks per-user billing totals (including total request quantity for convenience)
- * so the UI can render billing summaries without scanning raw rows or ProcessedData.
+ * Streams normalized rows through the shared BillingAccumulator so the UI can render
+ * billing summaries without duplicating billing-field accumulation in components.
  *
  * IMPORTANT:
  *  - We do NOT attempt to recompute costs from quantity * appliedCostPerQuantity.
@@ -20,120 +14,28 @@ import {
   Aggregator,
   AggregatorContext,
   BillingArtifacts,
-  BillingUserTotals,
-  NON_COPILOT_CODE_REVIEW_LABEL,
   NormalizedRow,
-  SpecialBillingBucketTotals,
-  SpecialUsageBucketKey
 } from './types';
-import { calculateAicPoolEstimate, calculateIncludedAicCreditsForUsers } from '@/utils/aicPool';
+import { BillingAccumulator } from './billingAccumulator';
 
 export class BillingAggregator implements Aggregator<BillingArtifacts> {
   readonly id = 'billing';
 
-  private grossTotal = 0;
-  private discountTotal = 0;
-  private netTotal = 0;
-  private aicQuantityTotal = 0;
-  private aicGrossAmountTotal = 0;
-  private userMap = new Map<string, BillingUserTotals>();
-  private specialBucketMap = new Map<SpecialUsageBucketKey, SpecialBillingBucketTotals>();
-  private hasAnyBillingData = false;
-  private hasAnyAicData = false;
+  private accumulator = new BillingAccumulator();
 
   init(_ctx: AggregatorContext): void {
     void _ctx;
-    this.grossTotal = 0;
-    this.discountTotal = 0;
-    this.netTotal = 0;
-    this.aicQuantityTotal = 0;
-    this.aicGrossAmountTotal = 0;
-    this.userMap.clear();
-    this.specialBucketMap.clear();
-    this.hasAnyBillingData = false;
-    this.hasAnyAicData = false;
+    this.accumulator = new BillingAccumulator();
   }
 
   onRow(row: NormalizedRow, _ctx: AggregatorContext): void {
     void _ctx;
-    let entry: BillingUserTotals | SpecialBillingBucketTotals | undefined;
-    if (row.isNonCopilotUsage && row.usageBucket) {
-      entry = this.specialBucketMap.get(row.usageBucket);
-      if (!entry) {
-        entry = {
-          key: row.usageBucket,
-          label: NON_COPILOT_CODE_REVIEW_LABEL,
-          quantity: 0,
-          quotaValue: 0
-        };
-        this.specialBucketMap.set(row.usageBucket, entry);
-      }
-    } else {
-      entry = this.userMap.get(row.user);
-      if (!entry) {
-        entry = { user: row.user, quantity: 0 };
-        this.userMap.set(row.user, entry);
-      }
-      if (entry.quotaValue === undefined && row.quotaValue !== undefined) {
-        entry.quotaValue = row.quotaValue;
-      }
-    }
-    entry.quantity += row.quantity;
-
-    let sawBilling = false;
-    if (typeof row.grossAmount === 'number') {
-      this.grossTotal += row.grossAmount;
-      entry.gross = (entry.gross || 0) + row.grossAmount;
-      sawBilling = true;
-    }
-    if (typeof row.discountAmount === 'number') {
-      this.discountTotal += row.discountAmount;
-      entry.discount = (entry.discount || 0) + row.discountAmount;
-      sawBilling = true;
-    }
-    if (typeof row.netAmount === 'number') {
-      this.netTotal += row.netAmount;
-      entry.net = (entry.net || 0) + row.netAmount;
-      sawBilling = true;
-    }
-    if (sawBilling) this.hasAnyBillingData = true;
-
-    if (typeof row.aicQuantity === 'number') {
-      this.aicQuantityTotal += row.aicQuantity;
-      entry.aicQuantity = (entry.aicQuantity || 0) + row.aicQuantity;
-    }
-    if (typeof row.aicGrossAmount === 'number') {
-      this.aicGrossAmountTotal += row.aicGrossAmount;
-      entry.aicGrossAmount = (entry.aicGrossAmount || 0) + row.aicGrossAmount;
-      this.hasAnyAicData = true;
-    }
+    this.accumulator.addRow(row);
   }
 
   finalize(_ctx: AggregatorContext): BillingArtifacts {
     void _ctx;
-    const poolEstimate = this.hasAnyAicData
-      ? calculateAicPoolEstimate(
-        calculateIncludedAicCreditsForUsers(this.userMap.values()),
-        this.aicGrossAmountTotal
-      )
-      : { includedCredits: 0, additionalUsageGrossAmount: 0 };
-
-    return {
-      totals: {
-        gross: this.grossTotal,
-        discount: this.discountTotal,
-        net: this.netTotal,
-        aicQuantity: this.aicQuantityTotal,
-        aicGrossAmount: this.aicGrossAmountTotal,
-        aicIncludedCredits: poolEstimate.includedCredits,
-        aicAdditionalUsageGrossAmount: poolEstimate.additionalUsageGrossAmount
-      },
-      users: Array.from(this.userMap.values()),
-      userMap: this.userMap,
-      hasAnyBillingData: this.hasAnyBillingData,
-      hasAnyAicData: this.hasAnyAicData,
-      specialBuckets: Array.from(this.specialBucketMap.values())
-    };
+    return this.accumulator.finalize();
   }
 }
 

--- a/src/utils/ingestion/billingAccumulator.ts
+++ b/src/utils/ingestion/billingAccumulator.ts
@@ -9,6 +9,7 @@ import {
   NON_COPILOT_CODE_REVIEW_LABEL,
   SpecialBillingBucketTotals,
   SpecialUsageBucketKey,
+  UNASSIGNED_BILLING_GROUP,
 } from './types';
 
 interface BillingAccumulatorRow {
@@ -138,8 +139,8 @@ export class BillingAccumulator {
     entry.quantity += row.quantity;
     addOptionalBillingFields(entry, row);
 
-    addGroupRow(this.orgTotals, row.organization || 'Unassigned', row);
-    addGroupRow(this.costCenterTotals, row.costCenter || 'Unassigned', row);
+    addGroupRow(this.orgTotals, row.organization || UNASSIGNED_BILLING_GROUP, row);
+    addGroupRow(this.costCenterTotals, row.costCenter || UNASSIGNED_BILLING_GROUP, row);
     addGroupRow(this.billingByModel, row.model, row);
 
     const signals = addBillingFields(this.totals, row);

--- a/src/utils/ingestion/billingAccumulator.ts
+++ b/src/utils/ingestion/billingAccumulator.ts
@@ -1,0 +1,187 @@
+import type { ProcessedData } from '@/types/csv';
+import { calculateAicPoolEstimate, calculateIncludedAicCreditsForUsers } from '@/utils/aicPool';
+
+import {
+  BillingArtifacts,
+  BillingFieldTotals,
+  BillingGroupTotals,
+  BillingUserTotals,
+  NON_COPILOT_CODE_REVIEW_LABEL,
+  SpecialBillingBucketTotals,
+  SpecialUsageBucketKey,
+} from './types';
+
+interface BillingAccumulatorRow {
+  user: string;
+  model: string;
+  quantity: number;
+  quotaValue?: number | 'unlimited';
+  organization?: string;
+  costCenter?: string;
+  grossAmount?: number;
+  discountAmount?: number;
+  netAmount?: number;
+  aicQuantity?: number;
+  aicGrossAmount?: number;
+  isNonCopilotUsage?: boolean;
+  usageBucket?: SpecialUsageBucketKey;
+}
+
+interface AccumulationSignals {
+  sawBilling: boolean;
+  sawAicGross: boolean;
+}
+
+function createBillingFieldTotals(): BillingFieldTotals {
+  return {
+    gross: 0,
+    discount: 0,
+    net: 0,
+    aicQuantity: 0,
+    aicGrossAmount: 0,
+  };
+}
+
+function createBillingGroupTotals(): BillingGroupTotals {
+  return {
+    ...createBillingFieldTotals(),
+    quantity: 0,
+  };
+}
+
+function addBillingFields(target: BillingFieldTotals, row: BillingAccumulatorRow): AccumulationSignals {
+  let sawBilling = false;
+  let sawAicGross = false;
+
+  if (typeof row.grossAmount === 'number') {
+    target.gross += row.grossAmount;
+    sawBilling = true;
+  }
+  if (typeof row.discountAmount === 'number') {
+    target.discount += row.discountAmount;
+    sawBilling = true;
+  }
+  if (typeof row.netAmount === 'number') {
+    target.net += row.netAmount;
+    sawBilling = true;
+  }
+  if (typeof row.aicQuantity === 'number') {
+    target.aicQuantity += row.aicQuantity;
+  }
+  if (typeof row.aicGrossAmount === 'number') {
+    target.aicGrossAmount += row.aicGrossAmount;
+    sawAicGross = true;
+  }
+
+  return { sawBilling, sawAicGross };
+}
+
+function addOptionalBillingFields(target: BillingUserTotals | SpecialBillingBucketTotals, row: BillingAccumulatorRow): void {
+  if (typeof row.grossAmount === 'number') {
+    target.gross = (target.gross || 0) + row.grossAmount;
+  }
+  if (typeof row.discountAmount === 'number') {
+    target.discount = (target.discount || 0) + row.discountAmount;
+  }
+  if (typeof row.netAmount === 'number') {
+    target.net = (target.net || 0) + row.netAmount;
+  }
+  if (typeof row.aicQuantity === 'number') {
+    target.aicQuantity = (target.aicQuantity || 0) + row.aicQuantity;
+  }
+  if (typeof row.aicGrossAmount === 'number') {
+    target.aicGrossAmount = (target.aicGrossAmount || 0) + row.aicGrossAmount;
+  }
+}
+
+function addGroupRow(groups: Map<string, BillingGroupTotals>, key: string, row: BillingAccumulatorRow): void {
+  const entry = groups.get(key) ?? createBillingGroupTotals();
+  entry.quantity += row.quantity;
+  addBillingFields(entry, row);
+  groups.set(key, entry);
+}
+
+export class BillingAccumulator {
+  private totals = createBillingFieldTotals();
+  private userMap = new Map<string, BillingUserTotals>();
+  private specialBucketMap = new Map<SpecialUsageBucketKey, SpecialBillingBucketTotals>();
+  private orgTotals = new Map<string, BillingGroupTotals>();
+  private costCenterTotals = new Map<string, BillingGroupTotals>();
+  private billingByModel = new Map<string, BillingGroupTotals>();
+  private hasAnyBillingData = false;
+  private hasAnyAicData = false;
+
+  addRow(row: BillingAccumulatorRow): void {
+    let entry: BillingUserTotals | SpecialBillingBucketTotals | undefined;
+    if (row.isNonCopilotUsage && row.usageBucket) {
+      entry = this.specialBucketMap.get(row.usageBucket);
+      if (!entry) {
+        entry = {
+          key: row.usageBucket,
+          label: NON_COPILOT_CODE_REVIEW_LABEL,
+          quantity: 0,
+          quotaValue: 0,
+        };
+        this.specialBucketMap.set(row.usageBucket, entry);
+      }
+    } else {
+      entry = this.userMap.get(row.user);
+      if (!entry) {
+        entry = { user: row.user, quantity: 0 };
+        this.userMap.set(row.user, entry);
+      }
+      if (entry.quotaValue === undefined && row.quotaValue !== undefined) {
+        entry.quotaValue = row.quotaValue;
+      }
+    }
+
+    entry.quantity += row.quantity;
+    addOptionalBillingFields(entry, row);
+
+    addGroupRow(this.orgTotals, row.organization || 'Unassigned', row);
+    addGroupRow(this.costCenterTotals, row.costCenter || 'Unassigned', row);
+    addGroupRow(this.billingByModel, row.model, row);
+
+    const signals = addBillingFields(this.totals, row);
+    if (signals.sawBilling) this.hasAnyBillingData = true;
+    if (signals.sawAicGross) this.hasAnyAicData = true;
+  }
+
+  finalize(): BillingArtifacts {
+    const poolEstimate = this.hasAnyAicData
+      ? calculateAicPoolEstimate(
+        calculateIncludedAicCreditsForUsers(this.userMap.values()),
+        this.totals.aicGrossAmount
+      )
+      : { includedCredits: 0, additionalUsageGrossAmount: 0 };
+
+    return {
+      totals: {
+        ...this.totals,
+        aicIncludedCredits: poolEstimate.includedCredits,
+        aicAdditionalUsageGrossAmount: poolEstimate.additionalUsageGrossAmount,
+      },
+      users: Array.from(this.userMap.values()),
+      userMap: this.userMap,
+      orgTotals: this.orgTotals,
+      costCenterTotals: this.costCenterTotals,
+      billingByModel: this.billingByModel,
+      hasAnyBillingData: this.hasAnyBillingData,
+      hasAnyAicData: this.hasAnyAicData,
+      specialBuckets: Array.from(this.specialBucketMap.values()),
+    };
+  }
+}
+
+export function buildBillingArtifactsFromProcessedData(rows: ProcessedData[]): BillingArtifacts {
+  const accumulator = new BillingAccumulator();
+
+  for (const row of rows) {
+    accumulator.addRow({
+      ...row,
+      quantity: row.requestsUsed,
+    });
+  }
+
+  return accumulator.finalize();
+}

--- a/src/utils/ingestion/index.ts
+++ b/src/utils/ingestion/index.ts
@@ -11,6 +11,7 @@ export * from './UsageAggregator';
 export * from './UsageAccumulator';
 export * from './DailyBucketsAggregator';
 export * from './BillingAggregator';
+export * from './billingAccumulator';
 export * from './FeatureUsageAggregator';
 export * from './RawDataAggregator';
 export * from './adapters';

--- a/src/utils/ingestion/types.ts
+++ b/src/utils/ingestion/types.ts
@@ -226,10 +226,25 @@ export interface BillingUserTotals {
   aicGrossAmount?: number;
 }
 
+export interface BillingFieldTotals {
+  gross: number;
+  discount: number;
+  net: number;
+  aicQuantity: number;
+  aicGrossAmount: number;
+}
+
+export interface BillingGroupTotals extends BillingFieldTotals {
+  quantity: number;
+}
+
 export interface BillingArtifacts {
-  totals: { gross: number; discount: number; net: number; aicQuantity: number; aicGrossAmount: number; aicIncludedCredits: number; aicAdditionalUsageGrossAmount: number };
+  totals: BillingFieldTotals & { aicIncludedCredits: number; aicAdditionalUsageGrossAmount: number };
   users: BillingUserTotals[]; // unsorted list; consumer may sort
   userMap: Map<string, BillingUserTotals>; // internal convenience map (exposed for advanced consumers)
+  orgTotals: Map<string, BillingGroupTotals>;
+  costCenterTotals: Map<string, BillingGroupTotals>;
+  billingByModel: Map<string, BillingGroupTotals>;
   hasAnyBillingData: boolean; // true if at least one billing numeric column encountered
   hasAnyAicData: boolean; // true if at least one AI Credits numeric column encountered
   specialBuckets?: SpecialBillingBucketTotals[];

--- a/src/utils/ingestion/types.ts
+++ b/src/utils/ingestion/types.ts
@@ -6,6 +6,7 @@ import { PRICING } from '@/constants/pricing';
 
 export const NON_COPILOT_CODE_REVIEW_BUCKET = 'non_copilot_code_review' as const;
 export const NON_COPILOT_CODE_REVIEW_LABEL = 'Non-Copilot Users' as const;
+export const UNASSIGNED_BILLING_GROUP = 'Unassigned' as const;
 
 export type SpecialUsageBucketKey = typeof NON_COPILOT_CODE_REVIEW_BUCKET;
 


### PR DESCRIPTION
Billing field accumulation was duplicated across the overview views, which made render paths rescan rows and made future billing fields harder to add consistently. This refactor moves billing totals into a shared accumulator used by ingestion and filtered UI artifacts, so gross, discount, net, AI credit gross, and grouped billing totals have one source of truth.

The shared accumulator now produces global, per-user, per-organization, per-cost-center, and per-model billing totals. The analysis context rebuilds billing artifacts from the currently filtered rows so billing summaries continue to respect selected billing periods, while the affected views consume artifact maps instead of maintaining their own billing loops.

| Commit | Change |
|--------|--------|
| `refactor: centralize billing accumulation` | Adds a shared billing accumulator, wires filtered billing artifacts into overview components, and covers grouped/non-Copilot billing totals in tests |
| `fix: address billing review feedback` | Removes an unnecessary allocation, centralizes the unassigned billing label, and adds direct wrapper coverage for filtered billing artifact rebuilds |

Validation:
- `npm run build && npm run lint && npm run test`

Closes #102