### PR TITLE
Add conditional AI Usage page

### DIFF
--- a/__tests__/components/DataAnalysisBilling.test.tsx
+++ b/__tests__/components/DataAnalysisBilling.test.tsx
@@ -57,6 +57,7 @@ describe('DataAnalysis billing summary', () => {
     });
 
     expect(screen.queryByText('Usage-based billing preview')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'AI Usage' })).not.toBeInTheDocument();
   });
 
   it('renders AI Credits callout and overview card when AIC fields are present', async () => {
@@ -133,6 +134,16 @@ describe('DataAnalysis billing summary', () => {
       expect(screen.getAllByRole('columnheader', { name: 'AI Credits Gross' })).toHaveLength(2);
       expect(screen.getAllByText('$0.27').length).toBeGreaterThan(0);
       expect(screen.getAllByText('$0.12').length).toBeGreaterThan(0);
+      expect(screen.getAllByRole('button', { name: 'AI Usage' }).length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'AI Usage' })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'AI Usage' })).toBeInTheDocument();
+      expect(screen.getByText('AI Credits User Clusters')).toBeInTheDocument();
+      expect(screen.getByRole('table', { name: 'AI Credits user clusters' })).toBeInTheDocument();
+      expect(screen.getByText('Heavy AIC users')).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Cost Centers' })[0]);

--- a/src/components/AiUsageOverview.tsx
+++ b/src/components/AiUsageOverview.tsx
@@ -1,32 +1,11 @@
 'use client';
 
-import { useMemo } from 'react';
-
 import { useAnalysisContext } from '@/context/AnalysisContext';
-import type { UserSummary } from '@/utils/analytics';
 
 import { UsersAicClustersChart } from './charts/UsersAicClustersChart';
 
 export function AiUsageOverview() {
-  const { billingArtifacts, userData } = useAnalysisContext();
-  const users = useMemo<UserSummary[]>(() => {
-    if (!billingArtifacts) {
-      return userData;
-    }
-
-    const usersByName = new Map(userData.map((user) => [user.user, user]));
-    for (const billingUser of billingArtifacts.users) {
-      if (!usersByName.has(billingUser.user)) {
-        usersByName.set(billingUser.user, {
-          user: billingUser.user,
-          totalRequests: billingUser.quantity,
-          modelBreakdown: {},
-        });
-      }
-    }
-
-    return Array.from(usersByName.values());
-  }, [billingArtifacts, userData]);
+  const { billingArtifacts } = useAnalysisContext();
 
   if (!billingArtifacts?.hasAnyAicData) {
     return (
@@ -58,7 +37,7 @@ export function AiUsageOverview() {
           </p>
         </div>
         <div className="p-5">
-          <UsersAicClustersChart users={users} userCosts={billingArtifacts.userMap} />
+          <UsersAicClustersChart users={billingArtifacts.users} />
         </div>
       </div>
     </div>

--- a/src/components/AiUsageOverview.tsx
+++ b/src/components/AiUsageOverview.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { useAnalysisContext } from '@/context/AnalysisContext';
+import type { UserSummary } from '@/utils/analytics';
+
+import { UsersAicClustersChart } from './charts/UsersAicClustersChart';
+
+export function AiUsageOverview() {
+  const { billingArtifacts, userData } = useAnalysisContext();
+  const users = useMemo<UserSummary[]>(() => {
+    if (!billingArtifacts) {
+      return userData;
+    }
+
+    const usersByName = new Map(userData.map((user) => [user.user, user]));
+    for (const billingUser of billingArtifacts.users) {
+      if (!usersByName.has(billingUser.user)) {
+        usersByName.set(billingUser.user, {
+          user: billingUser.user,
+          totalRequests: billingUser.quantity,
+          modelBreakdown: {},
+        });
+      }
+    }
+
+    return Array.from(usersByName.values());
+  }, [billingArtifacts, userData]);
+
+  if (!billingArtifacts?.hasAnyAicData) {
+    return (
+      <div className="w-full space-y-6">
+        <div>
+          <h2 className="text-2xl font-semibold tracking-tight text-[#1f2328]">AI Usage</h2>
+          <p className="text-sm text-[#636c76] mt-1">
+            AI Credits data is not available for the selected report.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold tracking-tight text-[#1f2328]">AI Usage</h2>
+        <p className="text-sm text-[#636c76] mt-1">
+          AI Credits consumption patterns across users, measured in USD gross usage.
+        </p>
+      </div>
+
+      <div className="bg-white border border-[#d1d9e0] rounded-md overflow-hidden">
+        <div className="px-5 py-4 border-b border-[#d1d9e0]">
+          <h3 className="text-sm font-medium text-[#1f2328]">AI Credits User Clusters</h3>
+          <p className="text-xs text-[#636c76] mt-0.5">
+            Typical user groups by AI Credits gross consumption in USD
+          </p>
+        </div>
+        <div className="p-5">
+          <UsersAicClustersChart users={users} userCosts={billingArtifacts.userMap} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/DataAnalysis.tsx
+++ b/src/components/DataAnalysis.tsx
@@ -9,6 +9,7 @@ import { calculateAicPoolEstimate } from '@/utils/aicPool';
 import { getModelColor } from '@/utils/modelColors';
 import { aggregateProductCosts } from '@/utils/productCosts';
 
+import { AiUsageOverview } from './AiUsageOverview';
 import { CodingAgentOverview } from './CodingAgentOverview';
 import { CostCentersOverview } from './CostCentersOverview';
 import { CostOptimizationInsights } from './CostOptimizationInsights';
@@ -25,7 +26,7 @@ interface DataAnalysisProps {
 }
 
 type NavigationItem = {
-  key: 'overview' | 'users' | 'costCenters' | 'organizations' | 'codingAgent' | 'insights' | 'costOptimization' | 'modelTrends';
+  key: 'overview' | 'users' | 'costCenters' | 'organizations' | 'codingAgent' | 'insights' | 'costOptimization' | 'modelTrends' | 'aiUsage';
   label: string;
   icon: React.ReactNode;
 };
@@ -111,6 +112,16 @@ const NAV_ITEMS: NavigationItem[] = [
   },
 ];
 
+const AI_USAGE_NAV_ITEM: NavigationItem = {
+  key: 'aiUsage' as const,
+  label: 'AI Usage',
+  icon: (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.091-3.091L2.25 12l2.846-.813a4.5 4.5 0 003.091-3.091L9 5.25l.813 2.846a4.5 4.5 0 003.091 3.091L15.75 12l-2.846.813a4.5 4.5 0 00-3.091 3.091zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.456-2.456L14.25 6l1.035-.259a3.375 3.375 0 002.456-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456zM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 00-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 001.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 001.423 1.423l1.183.394-1.183.394a2.25 2.25 0 00-1.423 1.423z" />
+    </svg>
+  ),
+};
+
 function DataAnalysisInner() {
   const {
     view,
@@ -147,14 +158,7 @@ function DataAnalysisInner() {
     return baseProcessed.some((row) => row.organization);
   }, [baseProcessed]);
 
-  useEffect(() => {
-    if (!hasCostCenters && view === 'costCenters') {
-      setView('overview');
-    }
-    if (!hasOrganizations && view === 'organizations') {
-      setView('overview');
-    }
-  }, [hasCostCenters, hasOrganizations, setView, view]);
+  const aicMetricsAvailable = billingArtifacts?.hasAnyAicData === true;
 
   const navItems = useMemo(() => {
     const items = [...NAV_ITEMS];
@@ -166,13 +170,27 @@ function DataAnalysisInner() {
     if (hasOrganizations) {
       items.splice(insertIdx, 0, ORGANIZATIONS_NAV_ITEM);
     }
+    if (aicMetricsAvailable) {
+      items.push(AI_USAGE_NAV_ITEM);
+    }
     return items;
-  }, [hasCostCenters, hasOrganizations]);
+  }, [aicMetricsAvailable, hasCostCenters, hasOrganizations]);
+
+  useEffect(() => {
+    if (!hasCostCenters && view === 'costCenters') {
+      setView('overview');
+    }
+    if (!hasOrganizations && view === 'organizations') {
+      setView('overview');
+    }
+    if (!aicMetricsAvailable && view === 'aiUsage') {
+      setView('overview');
+    }
+  }, [aicMetricsAvailable, hasCostCenters, hasOrganizations, setView, view]);
 
   const costMetricsAvailable = billingArtifacts?.hasAnyBillingData === true;
   const aggregatedCosts = costMetricsAvailable && billingArtifacts ? billingArtifacts.totals : null;
 
-  const aicMetricsAvailable = billingArtifacts?.hasAnyAicData === true;
   const aggregatedAic = (
     billingArtifacts?.hasAnyAicData
       ? {
@@ -356,6 +374,8 @@ function DataAnalysisInner() {
             <CostOptimizationInsights />
           ) : view === 'modelTrends' ? (
             <ModelUsageTrendsOverview />
+          ) : view === 'aiUsage' ? (
+            <AiUsageOverview />
           ) : (
             /* Overview — chart + model table */
             <div className="space-y-6">

--- a/src/components/charts/UsersAicClustersChart.tsx
+++ b/src/components/charts/UsersAicClustersChart.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import { useMemo } from 'react';
+import {
+  Cell,
+  CartesianGrid,
+  LabelList,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+  ZAxis,
+} from 'recharts';
+
+import type { UserSummary } from '@/utils/analytics';
+import type { BillingUserTotals } from '@/utils/ingestion';
+
+import { chartTooltipContentStyle, chartTooltipLabelStyle } from './chartTooltipStyles';
+
+interface UsersAicClustersChartProps {
+  users: UserSummary[];
+  userCosts: Map<string, BillingUserTotals>;
+}
+
+interface UserAicPoint {
+  user: string;
+  totalRequests: number;
+  aicGrossAmount: number;
+}
+
+interface UserAicCluster {
+  cluster: string;
+  users: number;
+  averageRequests: number;
+  averageAicGrossAmount: number;
+  totalRequests: number;
+  totalAicGrossAmount: number;
+  minAicGrossAmount: number;
+  maxAicGrossAmount: number;
+  shareOfAicGrossAmount: number;
+  fill: string;
+  dotClassName: string;
+}
+
+const CLUSTER_COLORS = ['#8c959f', '#60a5fa', '#6366f1', '#8b5cf6'];
+const CLUSTER_DOT_CLASSES = ['bg-[#8c959f]', 'bg-[#60a5fa]', 'bg-indigo-500', 'bg-[#8b5cf6]'];
+
+function formatUsd(value: number): string {
+  return `$${value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function summarizeCluster(
+  cluster: string,
+  points: UserAicPoint[],
+  totalAicGrossAmount: number,
+  fill: string,
+  dotClassName: string
+): UserAicCluster {
+  const totalRequests = points.reduce((sum, point) => sum + point.totalRequests, 0);
+  const clusterAicGrossAmount = points.reduce((sum, point) => sum + point.aicGrossAmount, 0);
+  const sortedSpend = points.map((point) => point.aicGrossAmount).sort((a, b) => a - b);
+
+  return {
+    cluster,
+    users: points.length,
+    averageRequests: totalRequests / points.length,
+    averageAicGrossAmount: clusterAicGrossAmount / points.length,
+    totalRequests,
+    totalAicGrossAmount: clusterAicGrossAmount,
+    minAicGrossAmount: sortedSpend[0] ?? 0,
+    maxAicGrossAmount: sortedSpend[sortedSpend.length - 1] ?? 0,
+    shareOfAicGrossAmount: totalAicGrossAmount > 0 ? (clusterAicGrossAmount / totalAicGrossAmount) * 100 : 0,
+    fill,
+    dotClassName,
+  };
+}
+
+function buildUserAicClusters(users: UserSummary[], userCosts: Map<string, BillingUserTotals>): UserAicCluster[] {
+  const points = users.map((user) => ({
+    user: user.user,
+    totalRequests: user.totalRequests,
+    aicGrossAmount: userCosts.get(user.user)?.aicGrossAmount ?? 0,
+  }));
+
+  const totalAicGrossAmount = points.reduce((sum, point) => sum + point.aicGrossAmount, 0);
+  const noSpendUsers = points.filter((point) => point.aicGrossAmount <= 0);
+  const spendingUsers = points
+    .filter((point) => point.aicGrossAmount > 0)
+    .sort((a, b) => a.aicGrossAmount - b.aicGrossAmount);
+
+  const clusters: UserAicCluster[] = [];
+
+  if (noSpendUsers.length > 0) {
+    clusters.push(summarizeCluster(
+      'No AIC spend',
+      noSpendUsers,
+      totalAicGrossAmount,
+      CLUSTER_COLORS[0],
+      CLUSTER_DOT_CLASSES[0]
+    ));
+  }
+
+  const bucketCount = Math.min(3, spendingUsers.length);
+  if (bucketCount === 0) {
+    return clusters;
+  }
+
+  const bucketNames = bucketCount === 1
+    ? ['AIC users']
+    : bucketCount === 2
+      ? ['Light AIC users', 'Heavy AIC users']
+      : ['Light AIC users', 'Typical AIC users', 'Heavy AIC users'];
+
+  for (let bucketIndex = 0; bucketIndex < bucketCount; bucketIndex += 1) {
+    const start = Math.floor((bucketIndex * spendingUsers.length) / bucketCount);
+    const end = Math.floor(((bucketIndex + 1) * spendingUsers.length) / bucketCount);
+    const bucketUsers = spendingUsers.slice(start, end);
+
+    if (bucketUsers.length > 0) {
+      clusters.push(summarizeCluster(
+        bucketNames[bucketIndex],
+        bucketUsers,
+        totalAicGrossAmount,
+        CLUSTER_COLORS[Math.min(bucketIndex + 1, CLUSTER_COLORS.length - 1)],
+        CLUSTER_DOT_CLASSES[Math.min(bucketIndex + 1, CLUSTER_DOT_CLASSES.length - 1)]
+      ));
+    }
+  }
+
+  return clusters;
+}
+
+export function UsersAicClustersChart({ users, userCosts }: UsersAicClustersChartProps) {
+  const clusters = useMemo(() => buildUserAicClusters(users, userCosts), [users, userCosts]);
+
+  if (users.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-64 text-[#636c76] text-sm">
+        No users match the current filters
+      </div>
+    );
+  }
+
+  if (clusters.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-64 text-[#636c76] text-sm">
+        No AI Credits consumption is available for the current users
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="h-72 sm:h-96 2xl:h-[28rem] w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <ScatterChart margin={{ top: 24, right: 28, bottom: 16, left: 16 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+            <XAxis
+              type="number"
+              dataKey="averageRequests"
+              name="Avg premium requests"
+              tick={{ fontSize: 12, fill: '#636c76' }}
+              axisLine={{ stroke: '#d1d9e0' }}
+              tickLine={{ stroke: '#d1d9e0' }}
+              tickFormatter={(value) => Number(value).toLocaleString(undefined, { maximumFractionDigits: 0 })}
+            />
+            <YAxis
+              type="number"
+              dataKey="averageAicGrossAmount"
+              name="Avg AI Credits gross"
+              tick={{ fontSize: 12, fill: '#636c76' }}
+              axisLine={{ stroke: '#d1d9e0' }}
+              tickLine={{ stroke: '#d1d9e0' }}
+              tickFormatter={(value) => formatUsd(Number(value))}
+            />
+            <ZAxis type="number" dataKey="users" range={[90, 900]} name="Users" />
+            <Tooltip
+              cursor={{ strokeDasharray: '3 3', stroke: '#d1d9e0' }}
+              contentStyle={chartTooltipContentStyle}
+              labelStyle={chartTooltipLabelStyle}
+              formatter={(value, name) => {
+                if (name === 'Avg AI Credits gross') return [formatUsd(Number(value)), name];
+                if (name === 'Avg premium requests') return [Number(value).toFixed(1), name];
+                return [Number(value).toLocaleString(), name];
+              }}
+            />
+            <Scatter name="User clusters" data={clusters} fill="#6366f1">
+              {clusters.map((cluster) => (
+                <Cell key={cluster.cluster} fill={cluster.fill} />
+              ))}
+              <LabelList dataKey="cluster" position="top" fill="#1f2328" fontSize={12} />
+            </Scatter>
+          </ScatterChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="overflow-auto border border-[#d1d9e0] rounded-md">
+        <table className="min-w-full" aria-label="AI Credits user clusters">
+          <thead>
+            <tr className="border-b border-[#d1d9e0]">
+              <th className="px-5 py-3 text-left text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
+                Cluster
+              </th>
+              <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
+                Users
+              </th>
+              <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
+                Avg AIC Gross
+              </th>
+              <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
+                Total AIC Gross
+              </th>
+              <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
+                Avg Requests
+              </th>
+              <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
+                AIC Share
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-[#d1d9e0]">
+            {clusters.map((cluster) => (
+              <tr key={cluster.cluster} className="hover:bg-[#fcfdff] transition-colors">
+                <td className="px-5 py-3 whitespace-nowrap text-sm font-medium text-[#1f2328]">
+                  <span className="inline-flex items-center gap-2">
+                    <span
+                      className={`w-2.5 h-2.5 rounded-full ${cluster.dotClassName}`}
+                      aria-hidden="true"
+                    />
+                    {cluster.cluster}
+                  </span>
+                  <p className="mt-0.5 text-xs font-normal text-[#636c76]">
+                    {formatUsd(cluster.minAicGrossAmount)}-{formatUsd(cluster.maxAicGrossAmount)} per user
+                  </p>
+                </td>
+                <td className="px-5 py-3 whitespace-nowrap text-sm font-mono tabular-nums text-[#636c76] text-right">
+                  {cluster.users.toLocaleString()}
+                </td>
+                <td className="px-5 py-3 whitespace-nowrap text-sm font-mono tabular-nums text-[#636c76] text-right">
+                  {formatUsd(cluster.averageAicGrossAmount)}
+                </td>
+                <td className="px-5 py-3 whitespace-nowrap text-sm font-mono tabular-nums font-semibold text-[#1f2328] text-right">
+                  {formatUsd(cluster.totalAicGrossAmount)}
+                </td>
+                <td className="px-5 py-3 whitespace-nowrap text-sm font-mono tabular-nums text-[#636c76] text-right">
+                  {cluster.averageRequests.toFixed(1)}
+                </td>
+                <td className="px-5 py-3 whitespace-nowrap text-sm font-mono tabular-nums text-[#636c76] text-right">
+                  {cluster.shareOfAicGrossAmount.toFixed(1)}%
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/charts/UsersAicClustersChart.tsx
+++ b/src/components/charts/UsersAicClustersChart.tsx
@@ -14,14 +14,12 @@ import {
   ZAxis,
 } from 'recharts';
 
-import type { UserSummary } from '@/utils/analytics';
 import type { BillingUserTotals } from '@/utils/ingestion';
 
 import { chartTooltipContentStyle, chartTooltipLabelStyle } from './chartTooltipStyles';
 
 interface UsersAicClustersChartProps {
-  users: UserSummary[];
-  userCosts: Map<string, BillingUserTotals>;
+  users: BillingUserTotals[];
 }
 
 interface UserAicPoint {
@@ -77,11 +75,11 @@ function summarizeCluster(
   };
 }
 
-function buildUserAicClusters(users: UserSummary[], userCosts: Map<string, BillingUserTotals>): UserAicCluster[] {
+function buildUserAicClusters(users: BillingUserTotals[]): UserAicCluster[] {
   const points = users.map((user) => ({
     user: user.user,
-    totalRequests: user.totalRequests,
-    aicGrossAmount: userCosts.get(user.user)?.aicGrossAmount ?? 0,
+    totalRequests: user.quantity,
+    aicGrossAmount: user.aicGrossAmount ?? 0,
   }));
 
   const totalAicGrossAmount = points.reduce((sum, point) => sum + point.aicGrossAmount, 0);
@@ -132,8 +130,8 @@ function buildUserAicClusters(users: UserSummary[], userCosts: Map<string, Billi
   return clusters;
 }
 
-export function UsersAicClustersChart({ users, userCosts }: UsersAicClustersChartProps) {
-  const clusters = useMemo(() => buildUserAicClusters(users, userCosts), [users, userCosts]);
+export function UsersAicClustersChart({ users }: UsersAicClustersChartProps) {
+  const clusters = useMemo(() => buildUserAicClusters(users), [users]);
 
   if (users.length === 0) {
     return (

--- a/src/context/AnalysisContext.tsx
+++ b/src/context/AnalysisContext.tsx
@@ -20,7 +20,7 @@ import {
 
 // Types
 type CopilotPlan = 'business' | 'enterprise';
-type ViewType = 'overview' | 'users' | 'costCenters' | 'organizations' | 'codingAgent' | 'insights' | 'costOptimization' | 'modelTrends';
+type ViewType = 'overview' | 'users' | 'costCenters' | 'organizations' | 'codingAgent' | 'insights' | 'costOptimization' | 'modelTrends' | 'aiUsage';
 
 interface AnalysisProviderProps {
   ingestionResult: IngestionResult;


### PR DESCRIPTION
AIC consumption needs a dedicated place in the report instead of being mixed into the Users table view. This adds a conditional AI Usage page that appears only when the uploaded report includes AI Credits data.

## Summary

- Adds a new AI Usage navigation item after Models when AIC data is available.
- Adds an AI Usage page with user clusters for no, light, typical, and heavy AI Credits gross consumption in USD.
- Keeps Users focused on quota and user table analysis by moving the cluster visualization out of that page.
- Guards the view state so AI Usage redirects away when the current report has no AIC data.
- Aligns AI Usage user clusters with the active billing period filter.

## Commit summary

| Commit | Change |
|--------|--------|
| `feat: add conditional AI Usage page` | Adds the conditional AI Usage page, AIC cluster chart/table, navigation wiring, and regression coverage. |
| `fix: align AI usage clusters with billing filters` | Uses filtered billing user totals for AI Usage clustering so request totals and AIC spend share the same time window. |

## Validation

- `npm run build`
- `npm run lint`
- `npm run test -- --runInBand`
