### PR TITLE
Add top AI Credits models table

### DIFF
--- a/__tests__/components/DataAnalysisBilling.test.tsx
+++ b/__tests__/components/DataAnalysisBilling.test.tsx
@@ -229,6 +229,84 @@ describe('DataAnalysis billing summary', () => {
     });
   });
 
+  it('renders the top three AI Credits models on the Models page', async () => {
+    const aicRows: CSVData[] = [
+      {
+        date: '2026-03-01',
+        username: 'test-user-one',
+        product: 'copilot',
+        sku: 'copilot_premium_request',
+        model: 'Model Alpha',
+        quantity: '10',
+        total_monthly_quota: '1000',
+        organization: 'test-org-one',
+        cost_center_name: 'test-cost-center-one',
+        aic_quantity: '50',
+        aic_gross_amount: '5',
+      },
+      {
+        date: '2026-03-02',
+        username: 'test-user-two',
+        product: 'copilot',
+        sku: 'copilot_premium_request',
+        model: 'Model Beta',
+        quantity: '20',
+        total_monthly_quota: '1000',
+        organization: 'test-org-one',
+        cost_center_name: 'test-cost-center-one',
+        aic_quantity: '100',
+        aic_gross_amount: '10',
+      },
+      {
+        date: '2026-03-03',
+        username: 'test-user-three',
+        product: 'copilot',
+        sku: 'copilot_premium_request',
+        model: 'Model Gamma',
+        quantity: '5',
+        total_monthly_quota: '1000',
+        organization: 'test-org-two',
+        cost_center_name: 'test-cost-center-two',
+        aic_quantity: '30',
+        aic_gross_amount: '3',
+      },
+      {
+        date: '2026-03-04',
+        username: 'test-user-four',
+        product: 'copilot',
+        sku: 'copilot_premium_request',
+        model: 'Model Delta',
+        quantity: '8',
+        total_monthly_quota: '1000',
+        organization: 'test-org-two',
+        cost_center_name: 'test-cost-center-two',
+        aic_quantity: '80',
+        aic_gross_amount: '8',
+      },
+    ];
+
+    const ingestionResult = createIngestionResultFromRawRows(aicRows);
+    render(<DataAnalysis ingestionResult={ingestionResult} filename="billing-export.csv" onReset={() => {}} />);
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Models' })[0]);
+
+    const topModelsTable = await screen.findByRole('table', { name: 'Top AI Credits models' });
+    const rows = within(topModelsTable).getAllByRole('row');
+
+    expect(screen.getByText(/Top 3 models drive/)).toHaveTextContent('Top 3 models drive 88.5% of total AI Credits consumption.');
+    expect(rows).toHaveLength(4);
+    expect(rows[1]).toHaveTextContent('#1');
+    expect(rows[1]).toHaveTextContent('Model Beta');
+    expect(rows[1]).toHaveTextContent('100.00');
+    expect(rows[1]).toHaveTextContent('$10.00');
+    expect(rows[1]).toHaveTextContent('38.5%');
+    expect(rows[2]).toHaveTextContent('Model Delta');
+    expect(rows[2]).toHaveTextContent('30.8%');
+    expect(rows[3]).toHaveTextContent('Model Alpha');
+    expect(rows[3]).toHaveTextContent('19.2%');
+    expect(within(topModelsTable).queryByText('Model Gamma')).not.toBeInTheDocument();
+  });
+
   it('renders AI Credits columns for zero-value new-format AIC fields', async () => {
     const zeroAicRows: CSVData[] = [{
       date: '2026-03-01',

--- a/__tests__/components/DataAnalysisBilling.test.tsx
+++ b/__tests__/components/DataAnalysisBilling.test.tsx
@@ -229,7 +229,7 @@ describe('DataAnalysis billing summary', () => {
     });
   });
 
-  it('renders the top three AI Credits models on the Models page', async () => {
+  it('renders the top three AI Credits models on the Models page with mixed AIC fields', async () => {
     const aicRows: CSVData[] = [
       {
         date: '2026-03-01',
@@ -242,7 +242,7 @@ describe('DataAnalysis billing summary', () => {
         organization: 'test-org-one',
         cost_center_name: 'test-cost-center-one',
         aic_quantity: '50',
-        aic_gross_amount: '5',
+        aic_gross_amount: '0.5',
       },
       {
         date: '2026-03-02',
@@ -255,7 +255,7 @@ describe('DataAnalysis billing summary', () => {
         organization: 'test-org-one',
         cost_center_name: 'test-cost-center-one',
         aic_quantity: '100',
-        aic_gross_amount: '10',
+        aic_gross_amount: '1',
       },
       {
         date: '2026-03-03',
@@ -268,7 +268,7 @@ describe('DataAnalysis billing summary', () => {
         organization: 'test-org-two',
         cost_center_name: 'test-cost-center-two',
         aic_quantity: '30',
-        aic_gross_amount: '3',
+        aic_gross_amount: '0.3',
       },
       {
         date: '2026-03-04',
@@ -281,7 +281,19 @@ describe('DataAnalysis billing summary', () => {
         organization: 'test-org-two',
         cost_center_name: 'test-cost-center-two',
         aic_quantity: '80',
-        aic_gross_amount: '8',
+        aic_gross_amount: '0.8',
+      },
+      {
+        date: '2026-03-05',
+        username: 'test-user-five',
+        product: 'copilot',
+        sku: 'copilot_premium_request',
+        model: 'Model Epsilon',
+        quantity: '12',
+        total_monthly_quota: '1000',
+        organization: 'test-org-three',
+        cost_center_name: 'test-cost-center-three',
+        aic_gross_amount: '1.2',
       },
     ];
 
@@ -293,17 +305,20 @@ describe('DataAnalysis billing summary', () => {
     const topModelsTable = await screen.findByRole('table', { name: 'Top AI Credits models' });
     const rows = within(topModelsTable).getAllByRole('row');
 
-    expect(screen.getByText(/Top 3 models drive/)).toHaveTextContent('Top 3 models drive 88.5% of total AI Credits consumption.');
+    expect(screen.getByText(/Top 3 models drive/)).toHaveTextContent('Top 3 models drive 78.9% of total AI Credits consumption.');
     expect(rows).toHaveLength(4);
     expect(rows[1]).toHaveTextContent('#1');
-    expect(rows[1]).toHaveTextContent('Model Beta');
-    expect(rows[1]).toHaveTextContent('100.00');
-    expect(rows[1]).toHaveTextContent('$10.00');
-    expect(rows[1]).toHaveTextContent('38.5%');
-    expect(rows[2]).toHaveTextContent('Model Delta');
-    expect(rows[2]).toHaveTextContent('30.8%');
-    expect(rows[3]).toHaveTextContent('Model Alpha');
-    expect(rows[3]).toHaveTextContent('19.2%');
+    expect(rows[1]).toHaveTextContent('Model Epsilon');
+    expect(rows[1]).toHaveTextContent('120.00');
+    expect(rows[1]).toHaveTextContent('$1.20');
+    expect(rows[1]).toHaveTextContent('31.6%');
+    expect(rows[2]).toHaveTextContent('Model Beta');
+    expect(rows[2]).toHaveTextContent('100.00');
+    expect(rows[2]).toHaveTextContent('$1.00');
+    expect(rows[2]).toHaveTextContent('26.3%');
+    expect(rows[3]).toHaveTextContent('Model Delta');
+    expect(rows[3]).toHaveTextContent('21.1%');
+    expect(within(topModelsTable).queryByText('Model Alpha')).not.toBeInTheDocument();
     expect(within(topModelsTable).queryByText('Model Gamma')).not.toBeInTheDocument();
   });
 

--- a/src/components/ModelUsageTrendsOverview.tsx
+++ b/src/components/ModelUsageTrendsOverview.tsx
@@ -1,14 +1,24 @@
 'use client';
 
 import React, { useMemo } from 'react';
+
 import { useAnalysisContext } from '@/context/AnalysisContext';
 import { ModelDailyStackedChart } from '@/components/charts/ModelDailyStackedChart';
-import { buildDailyModelUsageFromArtifacts } from '@/utils/ingestion/analytics';
 import { filterDailySeriesByMonths } from '@/utils/analytics/filters';
+import { formatCurrency } from '@/utils/formatters';
+import { buildDailyModelUsageFromArtifacts } from '@/utils/ingestion/analytics';
 import { generateModelColors } from '@/utils/modelColors';
 
+interface TopAicModelRow {
+  model: string;
+  requests: number;
+  aicQuantity: number;
+  aicGrossAmount: number;
+  share: number;
+}
+
 export function ModelUsageTrendsOverview() {
-  const { usageArtifacts, dailyBucketsArtifacts, selectedMonths } = useAnalysisContext();
+  const { usageArtifacts, dailyBucketsArtifacts, selectedMonths, billingArtifacts } = useAnalysisContext();
 
   const { data, models } = useMemo(() => {
     // For now, we ignore month filtering at the aggregation level and rely on
@@ -32,6 +42,58 @@ export function ModelUsageTrendsOverview() {
     return generateModelColors(models);
   }, [models]);
 
+  const topAicModelAnalysis = useMemo((): { rows: TopAicModelRow[]; topShare: number } => {
+    if (!billingArtifacts?.hasAnyAicData) {
+      return { rows: [], topShare: 0 };
+    }
+
+    const rows = Array.from(billingArtifacts.billingByModel.entries())
+      .map(([model, totals]) => ({
+        model,
+        requests: totals.quantity,
+        aicQuantity: totals.aicQuantity,
+        aicGrossAmount: totals.aicGrossAmount,
+      }))
+      .filter((row) => row.aicQuantity > 0 || row.aicGrossAmount > 0);
+
+    const hasCreditQuantity = rows.some((row) => row.aicQuantity > 0);
+    const totalConsumption = rows.reduce(
+      (sum, row) => sum + (hasCreditQuantity ? row.aicQuantity : row.aicGrossAmount),
+      0
+    );
+
+    const topRows = rows
+      .sort((left, right) => {
+        const leftConsumption = hasCreditQuantity ? left.aicQuantity : left.aicGrossAmount;
+        const rightConsumption = hasCreditQuantity ? right.aicQuantity : right.aicGrossAmount;
+
+        if (rightConsumption !== leftConsumption) {
+          return rightConsumption - leftConsumption;
+        }
+
+        return left.model.localeCompare(right.model);
+      })
+      .slice(0, 3)
+      .map((row) => {
+        const consumption = hasCreditQuantity ? row.aicQuantity : row.aicGrossAmount;
+        return {
+          ...row,
+          share: totalConsumption > 0 ? (consumption / totalConsumption) * 100 : 0,
+        };
+      });
+
+    const topConsumption = topRows.reduce(
+      (sum, row) => sum + (hasCreditQuantity ? row.aicQuantity : row.aicGrossAmount),
+      0
+    );
+
+    return {
+      rows: topRows,
+      topShare: totalConsumption > 0 ? (topConsumption / totalConsumption) * 100 : 0,
+    };
+  }, [billingArtifacts]);
+  const { rows: topAicModelRows, topShare: topAicModelShare } = topAicModelAnalysis;
+
   return (
     <div className="w-full space-y-6">
       <div>
@@ -40,6 +102,46 @@ export function ModelUsageTrendsOverview() {
           Daily stacked view by model (UTC)
         </p>
       </div>
+
+      {topAicModelRows.length > 0 && (
+        <div className="bg-white border border-[#d1d9e0] rounded-md overflow-hidden">
+          <div className="px-5 py-4 border-b border-[#d1d9e0]">
+            <h3 className="text-sm font-medium text-[#1f2328]">Top AI Credits Models</h3>
+            <p className="text-xs text-[#636c76] mt-0.5">Top 3 models by AI Credits consumed</p>
+            <p className="text-sm text-[#1f2328] mt-3">
+              Top 3 models drive <span className="font-semibold">{topAicModelShare.toFixed(1)}%</span> of total AI Credits consumption.
+            </p>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="min-w-full" aria-label="Top AI Credits models">
+              <thead>
+                <tr className="border-b border-[#d1d9e0]">
+                  <th className="px-5 py-3 text-left text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">Rank</th>
+                  <th className="px-5 py-3 text-left text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">Model</th>
+                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa] whitespace-nowrap">AI Credits</th>
+                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa] whitespace-nowrap">AI Credits Gross</th>
+                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa] whitespace-nowrap">Share</th>
+                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa] whitespace-nowrap">Requests</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[#d1d9e0]">
+                {topAicModelRows.map((row, index) => (
+                  <tr key={row.model} className="hover:bg-[#fcfdff] transition-colors">
+                    <td className="px-5 py-3 text-sm font-mono text-[#636c76]">#{index + 1}</td>
+                    <td className="px-5 py-3 text-sm font-medium text-[#1f2328]">{row.model}</td>
+                    <td className="px-5 py-3 text-sm font-mono font-semibold text-[#1f2328] text-right">
+                      {row.aicQuantity.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                    </td>
+                    <td className="px-5 py-3 text-sm font-mono text-[#636c76] text-right">{formatCurrency(row.aicGrossAmount)}</td>
+                    <td className="px-5 py-3 text-sm font-mono text-[#636c76] text-right">{row.share.toFixed(1)}%</td>
+                    <td className="px-5 py-3 text-sm font-mono text-[#636c76] text-right">{row.requests.toFixed(2)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
 
       <div className="bg-white border border-[#d1d9e0] rounded-md p-5 min-h-[20rem]">
         {data.length === 0 || models.length === 0 ? (

--- a/src/components/ModelUsageTrendsOverview.tsx
+++ b/src/components/ModelUsageTrendsOverview.tsx
@@ -2,6 +2,7 @@
 
 import React, { useMemo } from 'react';
 
+import { PRICING } from '@/constants/pricing';
 import { useAnalysisContext } from '@/context/AnalysisContext';
 import { ModelDailyStackedChart } from '@/components/charts/ModelDailyStackedChart';
 import { filterDailySeriesByMonths } from '@/utils/analytics/filters';
@@ -15,6 +16,12 @@ interface TopAicModelRow {
   aicQuantity: number;
   aicGrossAmount: number;
   share: number;
+}
+
+function getEffectiveAicQuantity(aicQuantity: number, aicGrossAmount: number): number {
+  const quantityDerivedFromGross = aicGrossAmount / PRICING.AI_CREDIT_USD_VALUE;
+
+  return Math.max(aicQuantity, quantityDerivedFromGross);
 }
 
 export function ModelUsageTrendsOverview() {
@@ -51,41 +58,28 @@ export function ModelUsageTrendsOverview() {
       .map(([model, totals]) => ({
         model,
         requests: totals.quantity,
-        aicQuantity: totals.aicQuantity,
+        aicQuantity: getEffectiveAicQuantity(totals.aicQuantity, totals.aicGrossAmount),
         aicGrossAmount: totals.aicGrossAmount,
       }))
       .filter((row) => row.aicQuantity > 0 || row.aicGrossAmount > 0);
 
-    const hasCreditQuantity = rows.some((row) => row.aicQuantity > 0);
-    const totalConsumption = rows.reduce(
-      (sum, row) => sum + (hasCreditQuantity ? row.aicQuantity : row.aicGrossAmount),
-      0
-    );
+    const totalConsumption = rows.reduce((sum, row) => sum + row.aicQuantity, 0);
 
     const topRows = rows
       .sort((left, right) => {
-        const leftConsumption = hasCreditQuantity ? left.aicQuantity : left.aicGrossAmount;
-        const rightConsumption = hasCreditQuantity ? right.aicQuantity : right.aicGrossAmount;
-
-        if (rightConsumption !== leftConsumption) {
-          return rightConsumption - leftConsumption;
+        if (right.aicQuantity !== left.aicQuantity) {
+          return right.aicQuantity - left.aicQuantity;
         }
 
         return left.model.localeCompare(right.model);
       })
       .slice(0, 3)
-      .map((row) => {
-        const consumption = hasCreditQuantity ? row.aicQuantity : row.aicGrossAmount;
-        return {
-          ...row,
-          share: totalConsumption > 0 ? (consumption / totalConsumption) * 100 : 0,
-        };
-      });
+      .map((row) => ({
+        ...row,
+        share: totalConsumption > 0 ? (row.aicQuantity / totalConsumption) * 100 : 0,
+      }));
 
-    const topConsumption = topRows.reduce(
-      (sum, row) => sum + (hasCreditQuantity ? row.aicQuantity : row.aicGrossAmount),
-      0
-    );
+    const topConsumption = topRows.reduce((sum, row) => sum + row.aicQuantity, 0);
 
     return {
       rows: topRows,


### PR DESCRIPTION
## Summary

The Models page should make it easier to identify which models are driving AI Credits consumption. This adds a ranked top-three table above the existing model usage chart so reviewers can quickly see the highest consuming models, their AI Credits totals, gross cost, request volume, and share of total consumption. The ranking normalizes mixed AI Credits datasets by deriving effective credits from gross amount when `aic_quantity` is absent.

| Commit | Change |
|--------|--------|
| `feat: add top AI credits models table` | Adds the Models page table and summary metric for top-three AI Credits contribution, with billing test coverage for ordering and share calculations. |
| `fix: normalize AI credits model ranking` | Handles mixed AI Credits data where some models have gross amount but no credit quantity, and expands coverage for that case. |

## Validation

- `npm run build && npm run lint && npm run test`