### PR TITLE
Normalize US M/D/YY dates from new AI Usage report

### DIFF
--- a/__tests__/utils/dateNormalization.test.ts
+++ b/__tests__/utils/dateNormalization.test.ts
@@ -1,0 +1,67 @@
+import {
+  createDateNormalizer,
+  detectDateFormat,
+  normalizeDateToIso,
+} from '@/utils/ingestion/dateNormalization';
+
+describe('dateNormalization', () => {
+  describe('detectDateFormat', () => {
+    it('detects ISO dates', () => {
+      expect(detectDateFormat('2026-03-11')).toBe('iso');
+      expect(detectDateFormat('2025-06-30T23:59:59Z')).toBe('iso');
+    });
+
+    it('detects US slash dates', () => {
+      expect(detectDateFormat('5/29/26')).toBe('us-slash');
+      expect(detectDateFormat('12/5/2026')).toBe('us-slash');
+    });
+
+    it('returns unknown for unsupported formats', () => {
+      expect(detectDateFormat('29.05.2026')).toBe('unknown');
+      expect(detectDateFormat('not-a-date')).toBe('unknown');
+      expect(detectDateFormat('')).toBe('unknown');
+    });
+  });
+
+  describe('normalizeDateToIso', () => {
+    it('passes ISO dates through as YYYY-MM-DD', () => {
+      expect(normalizeDateToIso('2026-03-11')).toBe('2026-03-11');
+      expect(normalizeDateToIso('2025-06-30T23:59:59Z')).toBe('2025-06-30');
+    });
+
+    it('converts US M/D/YY into ISO', () => {
+      expect(normalizeDateToIso('5/29/26')).toBe('2026-05-29');
+      expect(normalizeDateToIso('1/1/26')).toBe('2026-01-01');
+      expect(normalizeDateToIso('12/5/2026')).toBe('2026-12-05');
+    });
+
+    it('rejects out-of-range and malformed values', () => {
+      expect(normalizeDateToIso('13/1/26')).toBeNull();
+      expect(normalizeDateToIso('1/32/26')).toBeNull();
+      expect(normalizeDateToIso('29.05.2026')).toBeNull();
+      expect(normalizeDateToIso('garbage')).toBeNull();
+    });
+
+    it('never applies local-timezone conversion (string-only math)', () => {
+      // A naive `new Date("5/29/26")` would be timezone-dependent; the
+      // string parser must always yield the same UTC calendar date.
+      expect(normalizeDateToIso('5/29/26')).toBe('2026-05-29');
+    });
+  });
+
+  describe('createDateNormalizer', () => {
+    it('binds to a format and validates each value', () => {
+      const us = createDateNormalizer('us-slash');
+      expect(us('5/29/26')).toBe('2026-05-29');
+
+      const iso = createDateNormalizer('iso');
+      expect(iso('2026-03-11')).toBe('2026-03-11');
+    });
+
+    it('returns null for unknown format', () => {
+      const unknown = createDateNormalizer('unknown');
+      expect(unknown('5/29/26')).toBeNull();
+      expect(unknown('2026-03-11')).toBeNull();
+    });
+  });
+});

--- a/__tests__/utils/dateNormalization.test.ts
+++ b/__tests__/utils/dateNormalization.test.ts
@@ -42,6 +42,19 @@ describe('dateNormalization', () => {
       expect(normalizeDateToIso('garbage')).toBeNull();
     });
 
+    it('rejects impossible calendar dates', () => {
+      expect(normalizeDateToIso('4/31/26')).toBeNull();
+      expect(normalizeDateToIso('2/30/26')).toBeNull();
+      expect(normalizeDateToIso('2/29/26')).toBeNull();
+      expect(normalizeDateToIso('2026-04-31')).toBeNull();
+      expect(normalizeDateToIso('2026-02-29')).toBeNull();
+    });
+
+    it('accepts leap day in leap years', () => {
+      expect(normalizeDateToIso('2/29/24')).toBe('2024-02-29');
+      expect(normalizeDateToIso('2024-02-29')).toBe('2024-02-29');
+    });
+
     it('never applies local-timezone conversion (string-only math)', () => {
       // A naive `new Date("5/29/26")` would be timezone-dependent; the
       // string parser must always yield the same UTC calendar date.

--- a/__tests__/utils/ingestStreamDateFormat.test.ts
+++ b/__tests__/utils/ingestStreamDateFormat.test.ts
@@ -1,0 +1,114 @@
+import { ingestStream } from '@/utils/ingestion/orchestrator';
+import type { Aggregator, IngestionResult, NormalizedRow } from '@/utils/ingestion/types';
+
+interface FileLikeChunk {
+  content: string;
+}
+
+class MockFileReader {
+  onload: ((event: { target: { result: string } }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  error: Error | null = null;
+
+  readAsText(chunk: FileLikeChunk): void {
+    this.onload?.({ target: { result: chunk.content } });
+  }
+}
+
+function createStreamingCsvFile(csv: string): File {
+  const file = new File([csv], 'test-usage.csv', { type: 'text/csv' });
+  Object.defineProperty(file, 'size', { value: csv.length });
+  Object.defineProperty(file, 'slice', {
+    value: (start = 0, end = csv.length): FileLikeChunk => ({
+      content: csv.slice(start, end),
+    }),
+  });
+  return file;
+}
+
+function createCapturingAggregator(): Aggregator<NormalizedRow[]> {
+  const rows: NormalizedRow[] = [];
+
+  return {
+    id: 'capturedRows',
+    onRow: (row) => {
+      rows.push(row);
+    },
+    finalize: () => rows,
+  };
+}
+
+function ingestCsv(csv: string): Promise<IngestionResult> {
+  const originalFileReader = globalThis.FileReader;
+  globalThis.FileReader = MockFileReader as unknown as typeof FileReader;
+
+  return new Promise((resolve, reject) => {
+    ingestStream(createStreamingCsvFile(csv), [createCapturingAggregator()], {
+      onComplete: (result) => {
+        globalThis.FileReader = originalFileReader;
+        resolve(result);
+      },
+      onError: (error) => {
+        globalThis.FileReader = originalFileReader;
+        reject(new Error(error));
+      },
+    });
+  });
+}
+
+describe('ingestStream date format normalization', () => {
+  it('normalizes US slash dates through the streaming ingestion path', async () => {
+    const csv = [
+      'date,username,product,sku,model,quantity,exceeds_quota,total_monthly_quota,organization,cost_center_name',
+      '5/29/26,test-user-one,copilot,copilot_premium_request,Claude Sonnet 4,2,FALSE,1000,test-org-one,test-cost-center-one',
+      '6/1/26,test-user-two,copilot,copilot_premium_request,Code Review model,3,TRUE,300,test-org-two,test-cost-center-two',
+    ].join('\n');
+
+    const result = await ingestCsv(csv);
+    const rows = result.outputs.capturedRows as NormalizedRow[];
+
+    expect(result.rowsProcessed).toBe(2);
+    expect(result.warnings).toEqual([]);
+    expect(rows.map(row => row.date)).toEqual(['2026-05-29', '2026-06-01']);
+    expect(rows.map(row => row.day)).toEqual(['2026-05-29', '2026-06-01']);
+  });
+
+  it('warns and skips rows when the first streamed date format is unrecognized', async () => {
+    const csv = [
+      'date,username,product,sku,model,quantity,exceeds_quota,total_monthly_quota,organization,cost_center_name',
+      'May 29 2026,test-user-one,copilot,copilot_premium_request,Claude Sonnet 4,2,FALSE,1000,test-org-one,test-cost-center-one',
+      '2026-05-30,test-user-two,copilot,copilot_premium_request,Claude Sonnet 4,3,FALSE,1000,test-org-two,test-cost-center-two',
+    ].join('\n');
+
+    const result = await ingestCsv(csv);
+    const rows = result.outputs.capturedRows as NormalizedRow[];
+
+    expect(result.rowsProcessed).toBe(0);
+    expect(rows).toEqual([]);
+    expect(result.warnings).toContain('Unrecognized date format in CSV: May 29 2026');
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        'Unrecognized date format for user=test-user-one date=May 29 2026',
+        'Unrecognized date format for user=test-user-two date=2026-05-30',
+      ])
+    );
+  });
+
+  it('continues to normalize ISO dates through ingestStream', async () => {
+    const csv = [
+      'date,username,product,sku,model,quantity,exceeds_quota,total_monthly_quota,organization,cost_center_name',
+      '2026-05-29,test-user-one,copilot,copilot_premium_request,Claude Sonnet 4,2,FALSE,1000,test-org-one,test-cost-center-one',
+    ].join('\n');
+
+    const result = await ingestCsv(csv);
+    const rows = result.outputs.capturedRows as NormalizedRow[];
+
+    expect(result.rowsProcessed).toBe(1);
+    expect(result.warnings).toEqual([]);
+    expect(rows[0]).toMatchObject({
+      date: '2026-05-29',
+      day: '2026-05-29',
+      user: 'test-user-one',
+    });
+  });
+});

--- a/__tests__/utils/newFormatParsing.test.ts
+++ b/__tests__/utils/newFormatParsing.test.ts
@@ -41,6 +41,36 @@ describe('processCSVData (CSV format)', () => {
     });
   });
 
+  it('converts US M/D/YY dates (newer AI Usage report) into valid UTC timestamps', () => {
+    const rows: CSVData[] = [
+      {
+        date: '5/29/26',
+        username: 'test-user-one',
+        product: 'copilot',
+        sku: 'copilot_ai_credit',
+        model: 'Auto: Claude Haiku 4.5',
+        quantity: '96.9990345',
+        unit_type: 'ai-credits',
+        applied_cost_per_quantity: '0.01',
+        gross_amount: '0.969990345',
+        discount_amount: '0',
+        net_amount: '0.969990345',
+        total_monthly_quota: '3900',
+        organization: 'test-org-one',
+        cost_center_name: 'test-cost-center-one',
+        aic_quantity: '96.9990345',
+        aic_gross_amount: '0.969990345',
+      },
+    ];
+
+    const processed = processCSVData(rows);
+    expect(processed).toHaveLength(1);
+    expect(processed[0].timestamp.toISOString()).toBe('2026-05-29T00:00:00.000Z');
+    expect(processed[0].dateKey).toBe('2026-05-29');
+    expect(processed[0].monthKey).toBe('2026-05');
+    expect(processed[0].aicQuantity).toBeCloseTo(96.9990345);
+  });
+
   it('maps AI Credits fields from the billing report', () => {
     const rows: CSVData[] = [
       {

--- a/src/utils/ingestion/dateNormalization.ts
+++ b/src/utils/ingestion/dateNormalization.ts
@@ -28,8 +28,18 @@ function pad2(value: number): string {
   return value < 10 ? `0${value}` : String(value);
 }
 
-function isValidMonthDay(month: number, day: number): boolean {
-  return month >= 1 && month <= 12 && day >= 1 && day <= 31;
+function isLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+function daysInMonth(year: number, month: number): number {
+  if (month === 2) return isLeapYear(year) ? 29 : 28;
+  if (month === 4 || month === 6 || month === 9 || month === 11) return 30;
+  return 31;
+}
+
+function isValidMonthDay(year: number, month: number, day: number): boolean {
+  return month >= 1 && month <= 12 && day >= 1 && day <= daysInMonth(year, month);
 }
 
 /**
@@ -46,9 +56,10 @@ export function detectDateFormat(value: string): DateFormat {
 function normalizeIso(value: string): string | null {
   const match = ISO_DATE.exec(value.trim());
   if (!match) return null;
+  const year = Number(match[1]);
   const month = Number(match[2]);
   const day = Number(match[3]);
-  if (!isValidMonthDay(month, day)) return null;
+  if (!isValidMonthDay(year, month, day)) return null;
   return `${match[1]}-${match[2]}-${match[3]}`;
 }
 
@@ -57,8 +68,8 @@ function normalizeUsSlash(value: string): string | null {
   if (!match) return null;
   const month = Number(match[1]);
   const day = Number(match[2]);
-  if (!isValidMonthDay(month, day)) return null;
   const year = match[3].length === 2 ? TWO_DIGIT_YEAR_BASE + Number(match[3]) : Number(match[3]);
+  if (!isValidMonthDay(year, month, day)) return null;
   return `${year}-${pad2(month)}-${pad2(day)}`;
 }
 

--- a/src/utils/ingestion/dateNormalization.ts
+++ b/src/utils/ingestion/dateNormalization.ts
@@ -1,0 +1,89 @@
+/**
+ * Date normalization for CSV ingestion.
+ *
+ * Different versions of the GitHub Copilot usage report encode the `date`
+ * column differently:
+ *  - Legacy / current export: ISO `YYYY-MM-DD` (optionally with a time suffix).
+ *  - Newer AI Usage report:   US `M/D/YY` (e.g. `5/29/26`).
+ *
+ * Downstream code assumes the first 10 characters of the date are ISO
+ * `YYYY-MM-DD`. This module converts any supported input into that shape using
+ * pure string math only — it never allocates a `Date`, which both avoids
+ * per-row overhead and sidesteps the local-timezone interpretation that
+ * `new Date("5/29/26")` would apply (violating the app's UTC-only rule).
+ */
+
+export type DateFormat = 'iso' | 'us-slash' | 'unknown';
+
+/** Converts a single date value into ISO `YYYY-MM-DD`, or `null` if unsupported. */
+export type DateNormalizer = (value: string) => string | null;
+
+const ISO_DATE = /^(\d{4})-(\d{2})-(\d{2})/;
+const US_SLASH_DATE = /^(\d{1,2})\/(\d{1,2})\/(\d{2}|\d{4})$/;
+
+/** Two-digit years in the US format are assumed to be in the 2000s. */
+const TWO_DIGIT_YEAR_BASE = 2000;
+
+function pad2(value: number): string {
+  return value < 10 ? `0${value}` : String(value);
+}
+
+function isValidMonthDay(month: number, day: number): boolean {
+  return month >= 1 && month <= 12 && day >= 1 && day <= 31;
+}
+
+/**
+ * Detect the date format of a sample value (typically the first streamed row).
+ * Detection is purely structural; it does not attempt to infer month/day order.
+ */
+export function detectDateFormat(value: string): DateFormat {
+  const trimmed = value.trim();
+  if (ISO_DATE.test(trimmed)) return 'iso';
+  if (US_SLASH_DATE.test(trimmed)) return 'us-slash';
+  return 'unknown';
+}
+
+function normalizeIso(value: string): string | null {
+  const match = ISO_DATE.exec(value.trim());
+  if (!match) return null;
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (!isValidMonthDay(month, day)) return null;
+  return `${match[1]}-${match[2]}-${match[3]}`;
+}
+
+function normalizeUsSlash(value: string): string | null {
+  const match = US_SLASH_DATE.exec(value.trim());
+  if (!match) return null;
+  const month = Number(match[1]);
+  const day = Number(match[2]);
+  if (!isValidMonthDay(month, day)) return null;
+  const year = match[3].length === 2 ? TWO_DIGIT_YEAR_BASE + Number(match[3]) : Number(match[3]);
+  return `${year}-${pad2(month)}-${pad2(day)}`;
+}
+
+/**
+ * Create a normalizer bound to a detected format. Selecting the parser once
+ * (e.g. from the first streamed row) avoids re-detecting on every row. The
+ * returned normalizer still validates each value and returns `null` for inputs
+ * that do not match the expected format, so callers can warn and skip rather
+ * than crash on malformed data.
+ */
+export function createDateNormalizer(format: DateFormat): DateNormalizer {
+  switch (format) {
+    case 'iso':
+      return normalizeIso;
+    case 'us-slash':
+      return normalizeUsSlash;
+    default:
+      return () => null;
+  }
+}
+
+/**
+ * Universal normalizer that detects the format of each value individually.
+ * Used as the default when no pre-selected normalizer is supplied.
+ */
+export function normalizeDateToIso(value: string): string | null {
+  return createDateNormalizer(detectDateFormat(value))(value);
+}

--- a/src/utils/ingestion/normalizeRow.ts
+++ b/src/utils/ingestion/normalizeRow.ts
@@ -8,6 +8,7 @@ import type { CSVData } from '@/types/csv';
 import { isCodeReviewModel } from '@/utils/productClassification';
 import { isRequestUnitType } from '@/utils/unitType';
 
+import { normalizeDateToIso, type DateNormalizer } from './dateNormalization';
 import {
   NON_COPILOT_CODE_REVIEW_BUCKET,
   NormalizedRow,
@@ -20,11 +21,15 @@ import {
  * When `options.allowInvalidQuantity` is true, rows with a non-numeric quantity
  * are not rejected; instead the returned row will have `quantity` as `NaN`.
  * Callers using this option must handle NaN quantity values themselves.
+ *
+ * `options.normalizeDate` lets the streaming orchestrator inject a date parser
+ * selected once from the first row. When omitted, each value is detected
+ * individually via `normalizeDateToIso`.
  */
 export function normalizeRow(
   raw: CSVData | Record<string, unknown>,
   warnings: string[],
-  options: { allowInvalidQuantity?: boolean } = {}
+  options: { allowInvalidQuantity?: boolean; normalizeDate?: DateNormalizer } = {}
 ): NormalizedRow | null {
   const rawRecord = raw as Record<string, unknown>;
   const {
@@ -49,6 +54,14 @@ export function normalizeRow(
   
   // Type guard and validate required fields
   if (typeof date !== 'string' || typeof username !== 'string' || typeof model !== 'string' || quantity == null) {
+    return null;
+  }
+
+  // Normalize the date into ISO YYYY-MM-DD so downstream code can rely on it.
+  const normalizeDate = options.normalizeDate ?? normalizeDateToIso;
+  const isoDate = normalizeDate(date);
+  if (isoDate === null) {
+    warnings.push(`Unrecognized date format for user=${username} date=${date}`);
     return null;
   }
 
@@ -97,8 +110,8 @@ export function normalizeRow(
   };
 
   return {
-    date,
-    day: date.substring(0, 10), // Extract YYYY-MM-DD, preserving UTC
+    date: isoDate,
+    day: isoDate, // YYYY-MM-DD, UTC preserved (no timezone conversion)
     user: trimmedUsername,
     model,
     quantity: qty,

--- a/src/utils/ingestion/orchestrator.ts
+++ b/src/utils/ingestion/orchestrator.ts
@@ -5,6 +5,7 @@
 
 import Papa from 'papaparse';
 import { PRICING } from '@/constants/pricing';
+import { createDateNormalizer, detectDateFormat, type DateNormalizer } from './dateNormalization';
 import { normalizeRow } from './normalizeRow';
 import {
   Aggregator,
@@ -44,6 +45,10 @@ export function ingestStream(
   let rowsProcessed = 0;
   const warnings: string[] = [];
   const t0 = performance.now();
+
+  // Date parser is selected once from the first row that carries a date value,
+  // then reused for every subsequent row to avoid per-row format detection.
+  let dateNormalizer: DateNormalizer | undefined;
   
   Papa.parse(file, {
     header: true,
@@ -60,7 +65,18 @@ export function ingestStream(
       
       // Process each row in chunk
       for (const rawRow of data as Record<string, unknown>[]) {
-        const normalized = normalizeRow(rawRow, warnings);
+        if (!dateNormalizer) {
+          const rawDate = rawRow['date'];
+          if (typeof rawDate === 'string' && rawDate.trim() !== '') {
+            const format = detectDateFormat(rawDate);
+            if (format === 'unknown') {
+              warnings.push(`Unrecognized date format in CSV: ${rawDate}`);
+            }
+            dateNormalizer = createDateNormalizer(format);
+          }
+        }
+
+        const normalized = normalizeRow(rawRow, warnings, { normalizeDate: dateNormalizer });
         if (!normalized) continue;
         
         // Dispatch to all aggregators

--- a/src/utils/ingestion/types.ts
+++ b/src/utils/ingestion/types.ts
@@ -35,7 +35,7 @@ export interface SpecialBillingBucketTotals {
  * All aggregators receive this uniform shape.
  */
 export interface NormalizedRow {
-  date: string;            // Raw UTC timestamp string from CSV
+  date: string;            // Normalized YYYY-MM-DD (UTC preserved)
   day: string;             // Precomputed YYYY-MM-DD (UTC preserved)
   user: string;
   model: string;

--- a/src/utils/ingestion/types.ts
+++ b/src/utils/ingestion/types.ts
@@ -35,7 +35,7 @@ export interface SpecialBillingBucketTotals {
  * All aggregators receive this uniform shape.
  */
 export interface NormalizedRow {
-  date: string;            // Normalized YYYY-MM-DD (UTC preserved)
+  date: string;            // Source date: YYYY-MM-DD or full ISO timestamp
   day: string;             // Precomputed YYYY-MM-DD (UTC preserved)
   user: string;
   model: string;


### PR DESCRIPTION
## Why

The newer AI Usage report encodes the `date` column as US `M/D/YY` (for example `5/29/26`) instead of the ISO `YYYY-MM-DD` format the previous export used. Downstream ingestion assumed ISO and constructed `new Date("5/29/26T00:00:00Z")`, which is an Invalid Date. The subsequent `toISOString()` call threw, crashing the app immediately after a user uploaded one of these reports.

## What

Adds a localized date-normalization step to the ingestion pipeline so the rest of the code keeps receiving ISO dates exactly as before:

- ISO `YYYY-MM-DD` values pass through unchanged.
- US `M/D/YY` (and `M/D/YYYY`) slash dates are converted to ISO.
- Unsupported values emit a warning and are skipped rather than crashing.

The parser is selected once from the first streamed row and reused for every subsequent row, so we avoid re-detecting the format per line. Conversion uses pure string manipulation rather than `new Date(...)`, which both avoids an allocation per row and sidesteps local-timezone interpretation, keeping dates UTC-accurate as required for billing data.

## Notes for reviewers

- The format detection happens on the first row only; mixed-format files are not expected and would normalize according to the first row's detected parser.
- New unit tests cover ISO pass-through, US slash-date conversion, and unsupported-value handling.