### PR TITLE
fix: ignore non-billable quota sentinel in plan detection

### DIFF
--- a/__tests__/utils/dataAnalysis.test.ts
+++ b/__tests__/utils/dataAnalysis.test.ts
@@ -121,8 +121,8 @@ describe('CSV Data Processing', () => {
         model: 'claude-3.7-sonnet-thought',
         requestsUsed: 2.50,
         exceedsQuota: true,
-        totalQuota: '100',
-        quotaValue: 100
+        totalQuota: 'Unknown',
+        quotaValue: 'unknown'
       });
     });
 
@@ -161,7 +161,7 @@ describe('CSV Data Processing', () => {
       const result = analyzeData(processedData);
       
       expect(result.totalUniqueUsers).toBe(3); // test-user-a, test-user-b, test-user-c
-      expect(result.usersExceedingQuota).toBe(0); // Nobody actually exceeds their quota (test-user-b: 2.5/100, others unknown)
+      expect(result.usersExceedingQuota).toBe(0); // Nobody actually exceeds their quota (test-user-b: 2.5, unknown quota; others unknown)
       expect(result.requestsByModel).toHaveLength(4); // 4 different models
     });
 

--- a/__tests__/utils/mixedQuotas.test.ts
+++ b/__tests__/utils/mixedQuotas.test.ts
@@ -144,6 +144,53 @@ describe('Mixed Quota Support', () => {
     expect(analysis.quotaBreakdown.unknown).toEqual([]);
   });
 
+  it('should treat the non-billable quota sentinel as unknown', () => {
+    const sentinelData: CSVData[] = [
+      {
+        date: '2026-03-01',
+        username: 'test-user-one',
+        model: 'Claude Sonnet 4',
+        quantity: '5.00',
+        exceeds_quota: 'false',
+        total_monthly_quota: '2147483647'
+      }
+    ];
+
+    const processedData = processCSVData(sentinelData);
+
+    expect(processedData[0].quotaValue).toBe('unknown');
+    expect(processedData[0].totalQuota).toBe('Unknown');
+  });
+
+  it('should pick the highest known quota and ignore the sentinel', () => {
+    const mixedWithSentinel: CSVData[] = [
+      {
+        date: '2026-03-01',
+        username: 'test-user-one',
+        model: 'Claude Sonnet 4',
+        quantity: '5.00',
+        exceeds_quota: 'false',
+        total_monthly_quota: '1000'
+      },
+      {
+        date: '2026-03-02',
+        username: 'test-user-one',
+        model: 'Claude Sonnet 4',
+        quantity: '2.00',
+        exceeds_quota: 'false',
+        total_monthly_quota: '2147483647'
+      }
+    ];
+
+    const processedData = processCSVData(mixedWithSentinel);
+    const analysis = analyzeData(processedData);
+
+    expect(analysis.quotaBreakdown.enterprise).toEqual(['test-user-one']);
+    expect(analysis.quotaBreakdown.business).toEqual([]);
+    expect(analysis.quotaBreakdown.unknown).toEqual([]);
+    expect(analysis.quotaBreakdown.suggestedPlan).toBe('enterprise');
+  });
+
   it('should suggest enterprise plan for all enterprise users', () => {
     const enterpriseOnlyData: CSVData[] = [
       {

--- a/src/constants/pricing.ts
+++ b/src/constants/pricing.ts
@@ -9,6 +9,13 @@ export const PRICING = {
   ENTERPRISE_UPGRADE_DELTA: 20,
 } as const;
 
+// Recognized premium-request quota tiers. Any other numeric quota (e.g. the
+// 2147483647 sentinel emitted for non-billable events) is treated as unknown.
+export const KNOWN_QUOTA_VALUES: readonly number[] = [
+  PRICING.BUSINESS_QUOTA,
+  PRICING.ENTERPRISE_QUOTA,
+];
+
 // Cost optimization thresholds
 export const COST_OPTIMIZATION_THRESHOLDS = {
   MIN_OVERAGE_THRESHOLD: 100,

--- a/src/utils/analytics/quota.ts
+++ b/src/utils/analytics/quota.ts
@@ -1,4 +1,4 @@
-import { PRICING } from '@/constants/pricing';
+import { KNOWN_QUOTA_VALUES, PRICING } from '@/constants/pricing';
 import { ProcessedData } from '@/types/csv';
 import { isRequestUnitType } from '@/utils/unitType';
 
@@ -10,14 +10,19 @@ export interface QuotaBreakdownResult {
   suggestedPlan: 'business' | 'enterprise' | null;
 }
 
-// Parse quota value from string
+// Parse quota value from string. Only recognized quota tiers are kept as
+// numbers; anything else (blank, 'Unlimited', the non-billable sentinel, etc.)
+// resolves to 'unknown' so plan detection considers only known values.
 export function parseQuotaValue(quotaString: string): number | 'unknown' {
   const trimmed = quotaString.trim().toLowerCase();
   if (trimmed === 'unknown') {
     return 'unknown';
   }
   const parsed = parseInt(trimmed, 10);
-  return isNaN(parsed) ? 'unknown' : parsed;
+  if (isNaN(parsed) || !KNOWN_QUOTA_VALUES.includes(parsed)) {
+    return 'unknown';
+  }
+  return parsed;
 }
 
 export function shouldReplaceQuotaValue(

--- a/src/utils/ingestion/adapters.ts
+++ b/src/utils/ingestion/adapters.ts
@@ -31,7 +31,9 @@ export function buildProcessedDataFromRows(rows: NormalizedRow[] | undefined | n
       model: row.model,
       requestsUsed: row.quantity,
       exceedsQuota: row.exceedsQuota ?? false,
-      totalQuota: row.quotaRaw || (row.quotaValue === 'unknown' ? 'Unknown' : String(row.quotaValue ?? 'Unknown')),
+      totalQuota: row.quotaValue === 'unknown'
+        ? 'Unknown'
+        : (row.quotaRaw || String(row.quotaValue ?? 'Unknown')),
       quotaValue: row.quotaValue ?? 'unknown',
       product: row.product,
       sku: row.sku,


### PR DESCRIPTION
## Why

The billing export emits `2147483647` as `total_monthly_quota` for non-billable events. Plan detection assumes the highest numeric quota per user wins, so this sentinel overrode genuine `300`/`1000` tiers. A user with a real `1000` quota plus any non-billable row resolved to `2147483647`, which matches neither known tier. The result: the user was dropped from every quota bucket (business/enterprise/unknown) and received `0` included AIC credits.

## What

Resolve quota values against a known-tier set instead of trusting any numeric:

- Added `KNOWN_QUOTA_VALUES` to `src/constants/pricing.ts`, derived from `BUSINESS_QUOTA` and `ENTERPRISE_QUOTA` (per the project rule against hardcoding quota values).
- `parseQuotaValue` now returns `'unknown'` for any numeric outside that set. This single change flows through every consumer (max-selection, tier classification, billing/quota aggregators, and AIC credit calculation), so plan detection picks the max among known values and ignores unknowns.
- Display now falls back to `"Unknown"` whenever `quotaValue` is unknown, so the sentinel no longer leaks `2147483647` into the table.

Net effect: a user with `1000` + sentinel now correctly resolves to Enterprise rather than vanishing.

## Tests

- Added cases in `mixedQuotas.test.ts`: sentinel alone resolves to unknown, and `1000` + sentinel resolves to Enterprise with the right suggested plan.
- Updated a pre-existing `dataAnalysis` fixture assertion that relied on an arbitrary `100` value (not a real tier), which now correctly resolves to unknown.

## Notes

This generalizes beyond the specific `2147483647` value: any numeric that is not a recognized tier is treated as unknown. If a new quota tier is introduced, add it to `KNOWN_QUOTA_VALUES`.