### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/components/DataAnalysis.tsx
+++ b/src/components/DataAnalysis.tsx
@@ -124,7 +124,6 @@ function DataAnalysisInner() {
     setView,
     analysis,
     userData,
-    allModels,
     dailyCumulativeData,
     codingAgentAnalysis,
     codeReviewAnalysis,


### PR DESCRIPTION
The best fix is to remove `allModels` from the object destructuring assignment in `DataAnalysisInner` so only actually used context values are extracted.

- **General approach:** eliminate unused variables at their declaration site.
- **Specific change:** in `src/components/DataAnalysis.tsx`, inside `DataAnalysisInner()`, remove the `allModels,` entry from the `const { ... } = useAnalysisContext();` block.
- **No imports or new methods** are required.
- This does not change runtime behavior because the variable is unused.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._