### PR TITLE
Fix invalid date handling in ingestion adapter

### DIFF
--- a/__tests__/utils/newFormatParsing.test.ts
+++ b/__tests__/utils/newFormatParsing.test.ts
@@ -178,6 +178,42 @@ describe('processCSVData (CSV format)', () => {
     expect(special.totalQuota).toBe('0');
   });
 
+  it('reconstructs timestamps from the normalized UTC day', () => {
+    const rows: NormalizedRow[] = [{
+      date: '5/29/26',
+      day: '2026-05-29',
+      user: 'test-user-one',
+      model: 'Claude Sonnet 4',
+      quantity: 2,
+      quotaRaw: '1000',
+      quotaValue: 1000,
+      exceedsQuota: false,
+      product: 'copilot',
+      sku: 'copilot_premium_request',
+    }];
+
+    const processed = buildProcessedDataFromRows(rows);
+
+    expect(processed).toHaveLength(1);
+    expect(processed[0].timestamp.toISOString()).toBe('2026-05-29T00:00:00.000Z');
+    expect(processed[0].dateKey).toBe('2026-05-29');
+    expect(processed[0].monthKey).toBe('2026-05');
+  });
+
+  it('skips malformed adapter row dates with a warning instead of throwing', () => {
+    const warnings: string[] = [];
+    const rows: NormalizedRow[] = [{
+      date: 'not-a-date',
+      day: 'not-a-date',
+      user: 'test-user-one',
+      model: 'Claude Sonnet 4',
+      quantity: 2,
+    }];
+
+    expect(buildProcessedDataFromRows(rows, warnings)).toEqual([]);
+    expect(warnings).toEqual(['Unrecognized date format for user=test-user-one date=not-a-date']);
+  });
+
   it('keeps legacy CSV wrappers aligned with the normalized conversion path', () => {
     const rows: CSVData[] = [{
       date: '2025-10-04',

--- a/src/utils/ingestion/adapters.ts
+++ b/src/utils/ingestion/adapters.ts
@@ -5,6 +5,7 @@
 import type { CSVData, ProcessedData } from '@/types/csv';
 
 import { buildDateKeys } from '../dateKeys';
+import { normalizeDateToIso } from './dateNormalization';
 import { normalizeRow } from './normalizeRow';
 import {
   NormalizedRow,
@@ -14,18 +15,34 @@ import {
   DailyBucketsArtifacts,
 } from './types';
 
+function buildTimestampFromRowDate(row: NormalizedRow, warnings: string[]): Date | null {
+  const isoDate = normalizeDateToIso(row.day) ?? normalizeDateToIso(row.date);
+  if (isoDate === null) {
+    warnings.push(`Unrecognized date format for user=${row.user} date=${row.date}`);
+    return null;
+  }
+
+  return new Date(`${isoDate}T00:00:00Z`);
+}
+
 /**
  * Reconstructs a ProcessedData array from normalized rows.
  * Used by hooks that haven't been migrated to aggregator outputs yet.
  */
-export function buildProcessedDataFromRows(rows: NormalizedRow[] | undefined | null): ProcessedData[] {
+export function buildProcessedDataFromRows(
+  rows: NormalizedRow[] | undefined | null,
+  warnings: string[] = []
+): ProcessedData[] {
   if (!Array.isArray(rows) || rows.length === 0) {
     return [];
   }
-  return rows.map(row => {
-    const timestamp = new Date(`${row.date.substring(0, 10)}T00:00:00Z`);
+  const processed: ProcessedData[] = [];
+  for (const row of rows) {
+    const timestamp = buildTimestampFromRowDate(row, warnings);
+    if (timestamp === null) continue;
+
     const keys = buildDateKeys(timestamp);
-    return {
+    processed.push({
       timestamp,
       user: row.user,
       model: row.model,
@@ -47,8 +64,9 @@ export function buildProcessedDataFromRows(rows: NormalizedRow[] | undefined | n
       isNonCopilotUsage: row.isNonCopilotUsage,
       usageBucket: row.usageBucket,
       ...keys
-    };
-  });
+    });
+  }
+  return processed;
 }
 
 export function buildProcessedDataFromRawRows(
@@ -62,7 +80,7 @@ export function buildProcessedDataFromRawRows(
     .map(row => normalizeRow(row, warnings, { allowInvalidQuantity: true }))
     .filter((row): row is NormalizedRow => row !== null);
 
-  return buildProcessedDataFromRows(normalizedRows);
+  return buildProcessedDataFromRows(normalizedRows, warnings);
 }
 
 /**


### PR DESCRIPTION
Billing imports can include normalized rows whose original date value is not directly parseable by `Date`, which allowed malformed adapter rows to reach `Date.toISOString()` and crash the analysis view.

This change makes the adapter derive timestamps from the normalized UTC `day` value first, falls back through the existing date normalizer, and skips malformed adapter rows with a warning instead of constructing an invalid `Date`. Regression coverage verifies slash-formatted source dates keep the intended UTC billing day and malformed dates no longer throw.

| Commit | Change |
|--------|--------|
| `fix: handle normalized adapter dates safely` | Prevent invalid adapter dates from crashing date key generation and cover the regression in tests. |