### PR TITLE
Support usage-based AI Credits billing reports

### DIFF
--- a/__tests__/components/BillingGroupTable.test.tsx
+++ b/__tests__/components/BillingGroupTable.test.tsx
@@ -82,4 +82,28 @@ describe('BillingGroupTable', () => {
     expect(screen.queryByRole('columnheader', { name: 'Discount' })).not.toBeInTheDocument();
     expect(screen.queryByRole('columnheader', { name: 'Net' })).not.toBeInTheDocument();
   });
+
+  it('renders usage-based cost labels when supplied', () => {
+    render(
+      <BillingGroupTable
+        title="Cost Centers"
+        singularLabel="cost center"
+        nameColumnLabel="Cost Center"
+        rows={[billingRow]}
+        hasCosts={true}
+        hasAicGross={false}
+        detailIdPrefix="cost-center-details"
+        grossColumnLabel="Gross Amount"
+        discountColumnLabel="Included Credits"
+        netColumnLabel="Additional usage"
+      />
+    );
+
+    expect(screen.getByRole('columnheader', { name: 'Gross Amount' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Included Credits' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Additional usage' })).toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Gross' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Discount' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Net' })).not.toBeInTheDocument();
+  });
 });

--- a/__tests__/components/DataAnalysisBilling.test.tsx
+++ b/__tests__/components/DataAnalysisBilling.test.tsx
@@ -399,6 +399,85 @@ describe('DataAnalysis billing summary', () => {
     expect(table.getByText('$0.13')).toBeInTheDocument();
   });
 
+  it('renames discount and net billing labels for usage-based AI Credits reports', async () => {
+    const usageBasedRows: CSVData[] = [
+      {
+        date: '2026-06-01',
+        username: 'test-user-one',
+        product: 'copilot',
+        sku: 'copilot_ai_credit',
+        model: 'Auto: Claude Haiku 4.5',
+        quantity: '42.5',
+        unit_type: 'ai-credits',
+        applied_cost_per_quantity: '0.01',
+        gross_amount: '0.425',
+        discount_amount: '0.425',
+        net_amount: '0',
+        total_monthly_quota: '3900',
+        organization: 'test-org-one',
+        cost_center_name: 'test-cost-center-one',
+      },
+    ];
+
+    const ingestionResult = createIngestionResultFromRawRows(usageBasedRows);
+    render(<DataAnalysis ingestionResult={ingestionResult} filename="usage-based.csv" onReset={() => {}} />);
+
+    await waitFor(() => {
+      const billing = screen.getByLabelText('billing-summary');
+      expect(billing).toHaveTextContent('Included credits');
+      expect(billing).toHaveTextContent('Additional usage');
+      expect(billing).not.toHaveTextContent('Discounts');
+      expect(billing).not.toHaveTextContent('Net cost');
+      expect(screen.getByRole('heading', { name: 'AI Credits by Model' })).toBeInTheDocument();
+      expect(screen.queryByRole('heading', { name: 'Requests by Model' })).not.toBeInTheDocument();
+      expect(screen.getByText('Total: 42.50 AI Credits')).toBeInTheDocument();
+      expect(screen.getAllByRole('columnheader', { name: 'Included Credits' }).length).toBeGreaterThanOrEqual(2);
+      expect(screen.getAllByRole('columnheader', { name: 'Additional usage' }).length).toBeGreaterThanOrEqual(2);
+    });
+
+    const modelDetailsHeading = screen.getByRole('heading', { name: 'Model Details' });
+    const modelDetailsCard = modelDetailsHeading.closest('.bg-white');
+    expect(modelDetailsCard).not.toBeNull();
+    const modelDetailsTable = within(modelDetailsCard as HTMLElement).getByRole('table');
+    expect(within(modelDetailsTable).getByRole('columnheader', { name: 'AI Credits' })).toBeInTheDocument();
+    expect(within(modelDetailsTable).getByRole('columnheader', { name: 'Gross Amount' })).toBeInTheDocument();
+    expect(within(modelDetailsTable).getByRole('columnheader', { name: 'Included Credits' })).toBeInTheDocument();
+    expect(within(modelDetailsTable).getByRole('columnheader', { name: 'Additional usage' })).toBeInTheDocument();
+    expect(within(modelDetailsTable).queryByRole('columnheader', { name: 'Requests' })).not.toBeInTheDocument();
+    expect(within(modelDetailsTable).queryByRole('columnheader', { name: 'AI Credits Gross' })).not.toBeInTheDocument();
+    expect(within(modelDetailsTable).queryByRole('columnheader', { name: 'Gross' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Models' })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Model Usage Trends' })).toBeInTheDocument();
+      expect(screen.getByText('Daily stacked AI Credits by model (UTC)')).toBeInTheDocument();
+      expect(screen.queryByText('No model usage data available for the selected period.')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Cost Centers' })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Cost Centers' })).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'Gross Amount' })).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'Included Credits' })).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'Additional usage' })).toBeInTheDocument();
+      expect(screen.queryByRole('columnheader', { name: 'AI Credits Gross' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('columnheader', { name: 'Gross' })).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Organizations' })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Organizations' })).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'Gross Amount' })).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'Included Credits' })).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'Additional usage' })).toBeInTheDocument();
+      expect(screen.queryByRole('columnheader', { name: 'AI Credits Gross' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('columnheader', { name: 'Gross' })).not.toBeInTheDocument();
+    });
+  });
+
   it('renders cost per product and per-model billing details on the overview page', async () => {
     const billingRows: CSVData[] = [
       {

--- a/__tests__/components/UserDetailsView.test.tsx
+++ b/__tests__/components/UserDetailsView.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
 import { UserDetailsView } from '@/components/UserDetailsView';
+import { PRICING } from '@/constants/pricing';
 import type { ProcessedData } from '@/types/csv';
 
 jest.mock('recharts', () => ({
@@ -245,5 +246,58 @@ describe('UserDetailsView', () => {
     const opusDailyCells = within(opusDailyRow as HTMLElement).getAllByRole('cell');
     expect(opusDailyCells[3]).toHaveTextContent('$0.00');
     expect(opusDailyCells[4]).toHaveTextContent('$0.96');
+  });
+
+  it('uses usage-based billing columns in product and daily model breakdown tables', async () => {
+    const timestamp = new Date('2026-06-01T00:00:00Z');
+    const iso = timestamp.toISOString();
+    const processedData: ProcessedData[] = [{
+      timestamp,
+      user: 'test-user-one',
+      model: 'Auto: Claude Haiku 4.5',
+      requestsUsed: 0,
+      exceedsQuota: false,
+      totalQuota: PRICING.BUSINESS_AI_CREDIT_QUOTA.toString(),
+      quotaValue: PRICING.BUSINESS_AI_CREDIT_QUOTA,
+      iso,
+      dateKey: iso.slice(0, 10),
+      monthKey: iso.slice(0, 7),
+      epoch: timestamp.getTime(),
+      product: 'copilot',
+      sku: 'copilot_ai_credit',
+      unitType: 'ai-credits',
+      usageUnit: 'ai_credit',
+      billingQuantity: 42.5,
+      grossAmount: 0.425,
+      discountAmount: 0.425,
+      netAmount: 0,
+      aicGrossAmount: 0.425,
+    }];
+
+    render(
+      <UserDetailsView
+        user="test-user-one"
+        processedData={processedData}
+        userQuotaValue={PRICING.BUSINESS_AI_CREDIT_QUOTA}
+        onBack={mockOnBack}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Cost per Product')).toBeInTheDocument();
+      expect(screen.getByText('Daily Model Usage Breakdown')).toBeInTheDocument();
+      expect(screen.getAllByRole('columnheader', { name: 'AI Credits' })).toHaveLength(2);
+      expect(screen.getAllByRole('columnheader', { name: 'Gross Amount' })).toHaveLength(2);
+      expect(screen.queryByRole('columnheader', { name: 'AI Credits Gross' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('columnheader', { name: 'Requests' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('columnheader', { name: 'Gross' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('columnheader', { name: 'Gross Cost' })).not.toBeInTheDocument();
+    });
+
+    const dailyRow = screen.getByText('- Auto: Claude Haiku 4.5').closest('tr');
+    expect(dailyRow).not.toBeNull();
+    const dailyCells = within(dailyRow as HTMLElement).getAllByRole('cell');
+    expect(dailyCells[2]).toHaveTextContent('42.50');
+    expect(dailyCells[3]).toHaveTextContent('$0.43');
   });
 });

--- a/__tests__/components/UsersOverviewSorting.test.tsx
+++ b/__tests__/components/UsersOverviewSorting.test.tsx
@@ -204,6 +204,66 @@ describe('UsersOverview - sorting', () => {
     expect(within(table).getByText('$0.00')).toBeInTheDocument();
   });
 
+  it('shows usage-based billing columns and hides request-only columns', () => {
+    const userData: UserSummary[] = [
+      { user: 'test-user-one', totalRequests: 0, modelBreakdown: {} },
+      { user: 'test-user-two', totalRequests: 0, modelBreakdown: {} },
+      { user: 'test-user-three', totalRequests: 0, modelBreakdown: {} },
+    ];
+    const quotaArtifacts = makeQuota([
+      { user: 'test-user-one', quota: PRICING.BUSINESS_AI_CREDIT_QUOTA },
+      { user: 'test-user-two', quota: PRICING.ENTERPRISE_AI_CREDIT_QUOTA },
+      { user: 'test-user-three', quota: 'unknown' },
+    ]);
+    const timestamp = new Date('2026-06-01T00:00:00Z');
+    const makeUsageRow = (user: string, quotaValue: number | 'unknown', grossAmount: number): ProcessedData => ({
+      timestamp,
+      user,
+      model: 'Auto: Claude Haiku 4.5',
+      requestsUsed: 0,
+      exceedsQuota: false,
+      totalQuota: quotaValue === 'unknown' ? 'Unknown' : quotaValue.toString(),
+      quotaValue,
+      iso: timestamp.toISOString(),
+      dateKey: '2026-06-01',
+      monthKey: '2026-06',
+      epoch: timestamp.getTime(),
+      sku: 'copilot_ai_credit',
+      unitType: 'ai-credits',
+      usageUnit: 'ai_credit',
+      billingQuantity: grossAmount / PRICING.AI_CREDIT_USD_VALUE,
+      grossAmount,
+      discountAmount: grossAmount,
+      netAmount: 0,
+      aicGrossAmount: grossAmount,
+    });
+
+    render(
+      <UsersOverview
+        userData={userData}
+        processedData={[
+          makeUsageRow('test-user-one', PRICING.BUSINESS_AI_CREDIT_QUOTA, 0.1),
+          makeUsageRow('test-user-two', PRICING.ENTERPRISE_AI_CREDIT_QUOTA, 0.2),
+          makeUsageRow('test-user-three', 'unknown', 0.3),
+        ]}
+        dailyCumulativeData={[{ date: '2026-06-01T00:00:00Z' }]}
+        quotaArtifacts={quotaArtifacts}
+        usageArtifacts={makeUsage(userData)}
+      />
+    );
+
+    const table = screen.getByRole('table', { name: 'Users' });
+    expect(within(table).getByRole('columnheader', { name: /Plan/ })).toBeInTheDocument();
+    expect(within(table).getByRole('columnheader', { name: /Gross Amount/ })).toBeInTheDocument();
+    expect(within(table).queryByRole('columnheader', { name: /Quota/ })).not.toBeInTheDocument();
+    expect(within(table).queryByRole('columnheader', { name: /Total Requests/ })).not.toBeInTheDocument();
+    expect(within(table).queryByRole('columnheader', { name: 'AI Credits Gross' })).not.toBeInTheDocument();
+    expect(within(table).queryByRole('columnheader', { name: 'Gross' })).not.toBeInTheDocument();
+    expect(within(table).getByText('Business')).toBeInTheDocument();
+    expect(within(table).getByText('Enterprise')).toBeInTheDocument();
+    expect(within(table).getByText('Unknown')).toBeInTheDocument();
+  });
+
   it('sorts by quota (including Unknown) when clicking Quota header', () => {
     const userData: UserSummary[] = [
       { user: 'Alice', totalRequests: 10, modelBreakdown: { 'gpt-4': 10 } },

--- a/__tests__/utils/billingAggregator.test.ts
+++ b/__tests__/utils/billingAggregator.test.ts
@@ -144,6 +144,37 @@ describe('BillingAggregator', () => {
     expect(a.aicGrossAmount).toBeCloseTo(0.1);
   });
 
+  it('uses billing quantity and current AI Credits quotas for usage-based rows', () => {
+    const agg = new BillingAggregator();
+    agg.init?.(ctx);
+    agg.onRow(buildRow({
+      user: 'test-user-one',
+      sku: 'copilot_ai_credit',
+      unitType: 'ai-credits',
+      usageUnit: 'ai_credit',
+      quantity: 0,
+      billingQuantity: 42.726213,
+      quotaValue: PRICING.ENTERPRISE_AI_CREDIT_QUOTA,
+      grossAmount: 0.42726213,
+      discountAmount: 0.42726213,
+      netAmount: 0,
+      aicQuantity: 42.726213,
+      aicGrossAmount: 0.42726213,
+    }), ctx);
+
+    const out = agg.finalize(ctx);
+
+    expect(out.userMap.get('test-user-one')?.quantity).toBeCloseTo(42.726213);
+    expect(out.userMap.get('test-user-one')?.quotaValue).toBe(PRICING.ENTERPRISE_AI_CREDIT_QUOTA);
+    expect(out.totals.gross).toBeCloseTo(0.42726213);
+    expect(out.totals.discount).toBeCloseTo(0.42726213);
+    expect(out.totals.net).toBe(0);
+    expect(out.totals.aicQuantity).toBeCloseTo(42.726213);
+    expect(out.totals.aicGrossAmount).toBeCloseTo(0.42726213);
+    expect(out.totals.aicIncludedCredits).toBe(PRICING.ENTERPRISE_AI_CREDIT_QUOTA);
+    expect(out.totals.aicAdditionalUsageGrossAmount).toBe(0);
+  });
+
   it('estimates included AI Credits and additional usage gross by user quota', () => {
     const agg = new BillingAggregator();
     agg.init?.(ctx);

--- a/__tests__/utils/newFormatParsing.test.ts
+++ b/__tests__/utils/newFormatParsing.test.ts
@@ -68,7 +68,68 @@ describe('processCSVData (CSV format)', () => {
     expect(processed[0].timestamp.toISOString()).toBe('2026-05-29T00:00:00.000Z');
     expect(processed[0].dateKey).toBe('2026-05-29');
     expect(processed[0].monthKey).toBe('2026-05');
+    expect(processed[0].requestsUsed).toBe(0);
+    expect(processed[0].billingQuantity).toBeCloseTo(96.9990345);
     expect(processed[0].aicQuantity).toBeCloseTo(96.9990345);
+  });
+
+  it('supports current usage-based AI Credits billing rows using primary billing fields', () => {
+    const rows: CSVData[] = [
+      {
+        date: '2026-06-01',
+        username: 'test-user-one',
+        product: 'copilot',
+        sku: 'copilot_ai_credit',
+        model: 'Auto: Claude Haiku 4.5',
+        quantity: '42.726213',
+        unit_type: 'ai-credits',
+        applied_cost_per_quantity: '0.01',
+        gross_amount: '0.4272621300000001',
+        discount_amount: '0.4272621300000001',
+        net_amount: '0',
+        total_monthly_quota: '3900',
+        organization: 'test-org-one',
+        cost_center_name: '',
+        aic_quantity: '999',
+        aic_gross_amount: '999',
+      },
+      {
+        date: '2026-06-01',
+        username: 'test-user-two',
+        product: 'copilot',
+        sku: 'copilot_ai_credit',
+        model: 'Auto: GPT-5.3-Codex',
+        quantity: '5.447169000000001',
+        unit_type: 'ai-credit',
+        applied_cost_per_quantity: '0.01',
+        gross_amount: '0.054471689999999996',
+        discount_amount: '0.054471689999999996',
+        net_amount: '0',
+        total_monthly_quota: '1900',
+        organization: 'test-org-two',
+        cost_center_name: '',
+        aic_quantity: '888',
+        aic_gross_amount: '888',
+      },
+    ];
+
+    const processed = processCSVData(rows);
+
+    expect(processed).toHaveLength(2);
+    expect(processed[0]).toMatchObject({
+      requestsUsed: 0,
+      billingQuantity: 42.726213,
+      usageUnit: 'ai_credit',
+      quotaValue: 3900,
+      grossAmount: 0.4272621300000001,
+      discountAmount: 0.4272621300000001,
+      netAmount: 0,
+      aicQuantity: 42.726213,
+      aicGrossAmount: 0.4272621300000001,
+    });
+    expect(processed[1].quotaValue).toBe(1900);
+    expect(processed[1].aicQuantity).toBeCloseTo(5.447169);
+    expect(processed[1].aicGrossAmount).toBeCloseTo(0.05447169);
   });
 
   it('maps AI Credits fields from the billing report', () => {
@@ -245,6 +306,8 @@ describe('processCSVData (CSV format)', () => {
     expect(canonical[0]).toMatchObject({
       user: 'test-user-one',
       requestsUsed: 2.5,
+      billingQuantity: 2.5,
+      usageUnit: 'request',
       exceedsQuota: true,
       quotaValue: 300,
       totalQuota: '300',

--- a/__tests__/utils/quota.test.ts
+++ b/__tests__/utils/quota.test.ts
@@ -9,6 +9,9 @@ describe('shouldReplaceQuotaValue', () => {
     [300, 'unknown', false],
     [300, 1000, true],
     [1000, 300, false],
+    [1000, 1900, false],
+    [1900, 1000, true],
+    [1900, 3900, true],
     [300, 300, false],
     ['unknown', 'unknown', false],
   ] as const)('shouldReplaceQuotaValue(%p, %p) returns %p', (existing, incoming, expected) => {
@@ -70,5 +73,17 @@ describe('classifyQuotaMap', () => {
       mixed: false,
       suggestedPlan: null,
     });
+  });
+
+  test('buckets current AI Credits quota values by Copilot tier', () => {
+    const result = classifyQuotaMap(new Map<string, number | 'unknown'>([
+      ['test-user-one', PRICING.BUSINESS_AI_CREDIT_QUOTA],
+      ['test-user-two', PRICING.ENTERPRISE_AI_CREDIT_QUOTA],
+    ]));
+
+    expect(result.business).toEqual(['test-user-one']);
+    expect(result.enterprise).toEqual(['test-user-two']);
+    expect(result.unknown).toEqual([]);
+    expect(result.mixed).toBe(true);
   });
 });

--- a/src/components/BillingGroupTable.tsx
+++ b/src/components/BillingGroupTable.tsx
@@ -67,7 +67,7 @@ export function useBillingGroupRows<TExtra extends object>(
       }
 
       updateEntry?.(entry, row);
-      entry.requests += row.requestsUsed;
+      entry.requests += row.billingQuantity ?? row.requestsUsed;
       accumulateProductCost(entry.productBuckets, row);
     }
 
@@ -107,6 +107,10 @@ interface BillingGroupTableProps<T extends BillingGroupRow> {
   hasCosts: boolean;
   hasAicGross: boolean;
   detailIdPrefix: string;
+  quantityColumnLabel?: string;
+  grossColumnLabel?: string;
+  discountColumnLabel?: string;
+  netColumnLabel?: string;
   extraColumns?: Array<BillingGroupExtraColumn<T>>;
 }
 
@@ -122,6 +126,10 @@ export function BillingGroupTable<T extends BillingGroupRow>({
   hasCosts,
   hasAicGross,
   detailIdPrefix,
+  quantityColumnLabel = 'Requests',
+  grossColumnLabel = 'Gross',
+  discountColumnLabel = 'Discount',
+  netColumnLabel = 'Net',
   extraColumns = [],
 }: BillingGroupTableProps<T>) {
   const [expandedGroup, setExpandedGroup] = useState<string | null>(null);
@@ -144,15 +152,15 @@ export function BillingGroupTable<T extends BillingGroupRow>({
                     {column.header}
                   </th>
                 ))}
-                <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">Requests</th>
+                <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">{quantityColumnLabel}</th>
                 {hasAicGross && (
                   <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">AI Credits Gross</th>
                 )}
                 {hasCosts && (
                   <>
-                    <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">Gross</th>
-                    <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">Discount</th>
-                    <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">Net</th>
+                    <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">{grossColumnLabel}</th>
+                    <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">{discountColumnLabel}</th>
+                    <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">{netColumnLabel}</th>
                   </>
                 )}
               </tr>
@@ -221,15 +229,15 @@ export function BillingGroupTable<T extends BillingGroupRow>({
                               <thead>
                                 <tr className="border-b border-[#d1d9e0]">
                                   <th className="px-10 py-2 text-left text-xs font-bold text-[#636c76] uppercase tracking-wider">Product</th>
-                                  <th className="px-6 py-2 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">Requests</th>
+                                  <th className="px-6 py-2 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">{quantityColumnLabel}</th>
                                   {hasAicGross && (
                                     <th className="px-6 py-2 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">AI Credits Gross</th>
                                   )}
                                   {hasCosts && (
                                     <>
-                                      <th className="px-6 py-2 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">Gross</th>
-                                      <th className="px-6 py-2 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">Discount</th>
-                                      <th className="px-6 py-2 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">Net</th>
+                                      <th className="px-6 py-2 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">{grossColumnLabel}</th>
+                                      <th className="px-6 py-2 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">{discountColumnLabel}</th>
+                                      <th className="px-6 py-2 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">{netColumnLabel}</th>
                                     </>
                                   )}
                                 </tr>

--- a/src/components/CostCentersOverview.tsx
+++ b/src/components/CostCentersOverview.tsx
@@ -2,6 +2,7 @@
 
 import { BillingGroupTable, useBillingGroupRows } from '@/components/BillingGroupTable';
 import { useAnalysisContext } from '@/context/AnalysisContext';
+import { getBillingCostLabels } from '@/utils/billingLabels';
 import { UNASSIGNED_BILLING_GROUP } from '@/utils/ingestion';
 
 export function CostCentersOverview() {
@@ -15,6 +16,11 @@ export function CostCentersOverview() {
 
   const hasCosts = costCenterRows.some(r => r.gross > 0 || r.net > 0);
   const hasAicGross = billingArtifacts?.hasAnyAicData === true;
+  const hasAiCreditUsage = aggregateProcessedData.some((row) => row.usageUnit === 'ai_credit');
+  const hasRequestUsage = aggregateProcessedData.some((row) => row.usageUnit === 'request' && row.requestsUsed > 0);
+  const isUsageBasedBilling = hasAiCreditUsage && !hasRequestUsage;
+  const quantityColumnLabel = isUsageBasedBilling ? 'AI Credits' : 'Requests';
+  const costLabels = getBillingCostLabels(isUsageBasedBilling);
 
   return (
     <BillingGroupTable
@@ -23,8 +29,12 @@ export function CostCentersOverview() {
       nameColumnLabel="Cost Center"
       rows={costCenterRows}
       hasCosts={hasCosts}
-      hasAicGross={hasAicGross}
+      hasAicGross={hasAicGross && !isUsageBasedBilling}
       detailIdPrefix="cost-center-details"
+      quantityColumnLabel={quantityColumnLabel}
+      grossColumnLabel={costLabels.gross}
+      discountColumnLabel={costLabels.discount}
+      netColumnLabel={costLabels.net}
     />
   );
 }

--- a/src/components/DataAnalysis.tsx
+++ b/src/components/DataAnalysis.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useMemo } from 'react';
 import { PRICING } from '@/constants/pricing';
 import { AnalysisProvider, useAnalysisContext } from '@/context/AnalysisContext';
 import { aggregateAutoModeSavings } from '@/utils/autoModeSavings';
+import { getBillingCostLabels } from '@/utils/billingLabels';
 import { formatCurrency } from '@/utils/formatters';
 import { getModelColor } from '@/utils/modelColors';
 import { aggregateProductCosts } from '@/utils/productCosts';
@@ -137,7 +138,6 @@ function DataAnalysisInner() {
     setSelectedMonths,
     planInfo,
     selectedPlan,
-    chartData,
     filename,
     quotaArtifacts,
     usageArtifacts,
@@ -154,6 +154,33 @@ function DataAnalysisInner() {
   }, [baseProcessed]);
 
   const aicMetricsAvailable = billingArtifacts?.hasAnyAicData === true;
+  const hasAiCreditUsage = useMemo(
+    () => aggregateProcessedData.some((row) => row.usageUnit === 'ai_credit'),
+    [aggregateProcessedData]
+  );
+  const hasRequestUsage = useMemo(
+    () => aggregateProcessedData.some((row) => row.usageUnit === 'request' && row.requestsUsed > 0),
+    [aggregateProcessedData]
+  );
+  const isUsageBasedBilling = hasAiCreditUsage && !hasRequestUsage;
+  const quantityColumnLabel = isUsageBasedBilling ? 'AI Credits' : 'Requests';
+  const billingQuantityLabel = isUsageBasedBilling ? 'AI Credits' : 'PRUs';
+  const costLabels = getBillingCostLabels(isUsageBasedBilling);
+  const unitCostLabel = isUsageBasedBilling
+    ? `1 AI Credit = ${formatCurrency(PRICING.AI_CREDIT_USD_VALUE)}`
+    : `1 PRU = ${formatCurrency(PRICING.OVERAGE_RATE_PER_REQUEST)}`;
+  const monthlyQuotaDisplay = useMemo(() => {
+    if (analysis.quotaBreakdown.mixed) {
+      return 'Mixed';
+    }
+
+    const distinctQuotas = Array.from(quotaArtifacts.distinctQuotas);
+    if (distinctQuotas.length === 1) {
+      return distinctQuotas[0].toLocaleString();
+    }
+
+    return planInfo[selectedPlan].monthlyQuota.toLocaleString();
+  }, [analysis.quotaBreakdown.mixed, planInfo, quotaArtifacts.distinctQuotas, selectedPlan]);
 
   const navItems = useMemo(() => {
     const items = [...NAV_ITEMS];
@@ -224,7 +251,22 @@ function DataAnalysisInner() {
   const hasModelCosts = modelRows.some(
     (row) => row.gross > 0 || row.discount > 0 || row.net > 0
   );
-  const hasModelAic = aicMetricsAvailable;
+  const showModelQuantity = true;
+  const hasModelAic = aicMetricsAvailable && !isUsageBasedBilling;
+  const modelChartData = useMemo(() => (
+    modelRows.map((item) => ({
+      model: item.model.length > 20 ? `${item.model.substring(0, 20)}...` : item.model,
+      fullModel: item.model,
+      requests: Math.round(item.requests * 100) / 100,
+    }))
+  ), [modelRows]);
+  const modelChartTotal = modelRows.reduce((sum, model) => sum + model.requests, 0);
+  const modelChartTitle = isUsageBasedBilling ? 'AI Credits by Model' : 'Requests by Model';
+  const modelChartValueLabel = isUsageBasedBilling ? 'AI Credits' : 'Total Requests';
+  const modelChartUnitLabel = isUsageBasedBilling ? 'AI Credits' : 'requests';
+  const modelChartTotalDisplay = isUsageBasedBilling
+    ? modelChartTotal.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+    : modelChartTotal.toFixed(0);
 
   const productCosts = useMemo(() => aggregateProductCosts(aggregateProcessedData), [aggregateProcessedData]);
   const showProductAicGross = aicMetricsAvailable;
@@ -409,10 +451,10 @@ function DataAnalysisInner() {
                       {formatCurrency(aggregatedCosts.net)}
                     </p>
                     <p className="text-sm text-[#636c76] text-center mt-1">
-                      {aggregateProcessedData.reduce((sum, r) => sum + r.requestsUsed, 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} PRUs
+                      {aggregateProcessedData.reduce((sum, r) => sum + (r.billingQuantity ?? r.requestsUsed), 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} {billingQuantityLabel}
                     </p>
                     <p className="text-xs text-[#636c76] text-center mt-0.5">
-                      1 PRU = {formatCurrency(PRICING.OVERAGE_RATE_PER_REQUEST)}
+                      {unitCostLabel}
                     </p>
                     <div className="mt-4 pt-4 border-t border-[#d1d9e0] space-y-2 text-sm" aria-label="billing-summary">
                       <div className="flex justify-between">
@@ -422,13 +464,13 @@ function DataAnalysisInner() {
                         </span>
                       </div>
                       <div className="flex justify-between">
-                        <span className="text-[#636c76]">Discounts</span>
+                        <span className="text-[#636c76]">{costLabels.discountSummary}</span>
                         <span className="font-mono font-medium text-[#1f2328]">
                           &minus;{formatCurrency(aggregatedCosts.discount)}
                         </span>
                       </div>
                       <div className="flex justify-between pt-2 mt-2 border-t-2 border-[#d1d9e0]">
-                        <span className="text-[#1f2328] font-bold">Net cost</span>
+                        <span className="text-[#1f2328] font-bold">{costLabels.netSummary}</span>
                         <span className="font-mono font-bold text-[#1f2328]">
                           {formatCurrency(aggregatedCosts.net)}
                         </span>
@@ -495,7 +537,7 @@ function DataAnalysisInner() {
                           </span>
                         </div>
                         <p className="text-xs text-[#636c76]">
-                          Estimated values. Gross cost excludes any discounts applied to the final bill.
+                          Estimated values. Gross cost excludes any included credits applied to the final bill.
                         </p>
                       </div>
                     </div>
@@ -514,15 +556,15 @@ function DataAnalysisInner() {
                       <thead>
                         <tr className="border-b border-[#d1d9e0]">
                           <th className="px-6 py-3 text-left text-xs font-bold text-[#636c76] uppercase tracking-wider">Product</th>
-                          <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">Requests</th>
+                          <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">{quantityColumnLabel}</th>
                           {showProductAicGross && (
                             <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">AI Credits Gross</th>
                           )}
                           {showProductCosts && (
                             <>
                               <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">Gross</th>
-                              <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">Discount</th>
-                              <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">Net</th>
+                              <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">{costLabels.discount}</th>
+                              <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">{costLabels.net}</th>
                             </>
                           )}
                         </tr>
@@ -568,7 +610,7 @@ function DataAnalysisInner() {
                       <thead>
                         <tr className="border-b border-[#d1d9e0]">
                           <th className="px-6 py-3 text-left text-xs font-bold text-[#636c76] uppercase tracking-wider">Model</th>
-                          <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">Requests</th>
+                          <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">{quantityColumnLabel}</th>
                           <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">Cost Before Auto</th>
                           <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">Savings</th>
                         </tr>
@@ -598,11 +640,15 @@ function DataAnalysisInner() {
 
               <div className="bg-white border border-[#d1d9e0] rounded-md p-6 opacity-0 animate-scale-in" style={{ animationDelay: '200ms' }}>
                 <div className="flex items-center justify-between mb-6">
-                  <h3 className="text-lg font-semibold text-[#1f2328]">Requests by Model</h3>
-                  <span className="text-xs text-[#636c76] font-medium">Total: {analysis.requestsByModel.reduce((sum, m) => sum + m.totalRequests, 0).toFixed(0)} requests</span>
+                  <h3 className="text-lg font-semibold text-[#1f2328]">{modelChartTitle}</h3>
+                  <span className="text-xs text-[#636c76] font-medium">Total: {modelChartTotalDisplay} {modelChartUnitLabel}</span>
                 </div>
                 <div className="h-72 xl:h-80 2xl:h-96">
-                  <ModelRequestsBarChart data={chartData} />
+                  <ModelRequestsBarChart
+                    data={modelChartData}
+                    valueLabel={modelChartValueLabel}
+                    valueUnitLabel={modelChartUnitLabel}
+                  />
                 </div>
               </div>
 
@@ -615,15 +661,17 @@ function DataAnalysisInner() {
                     <thead>
                       <tr className="border-b border-[#d1d9e0]">
                         <th className="px-6 py-3 text-left text-xs font-bold text-[#636c76] uppercase tracking-wider">Model</th>
-                        <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">Requests</th>
+                        {showModelQuantity && (
+                          <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">{quantityColumnLabel}</th>
+                        )}
                         {hasModelAic && (
                           <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">AI Credits Gross</th>
                         )}
                         {hasModelCosts && (
                           <>
-                            <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">Gross</th>
-                            <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">Discount</th>
-                            <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">Net</th>
+                            <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">{costLabels.gross}</th>
+                            <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">{costLabels.discount}</th>
+                            <th className="px-6 py-3 text-right text-xs font-bold text-[#636c76] uppercase tracking-wider">{costLabels.net}</th>
                           </>
                         )}
                       </tr>
@@ -638,9 +686,11 @@ function DataAnalysisInner() {
                                 {item.model}
                               </div>
                             </td>
-                            <td className="px-6 py-3.5 text-sm text-[#636c76] text-right font-mono">
-                              {item.requests.toFixed(2)}
-                            </td>
+                            {showModelQuantity && (
+                              <td className="px-6 py-3.5 text-sm text-[#636c76] text-right font-mono">
+                                {item.requests.toFixed(2)}
+                              </td>
+                            )}
                             {hasModelAic && (
                               <td className="px-6 py-3.5 text-sm text-[#636c76] text-right font-mono">
                                 {formatCurrency(item.aicGrossAmount)}
@@ -679,10 +729,7 @@ function DataAnalysisInner() {
               <div className="flex items-center justify-between p-3 bg-[#f6f8fa] rounded-md border border-[#d1d9e0]">
                 <span className="text-xs font-medium text-[#636c76]">Monthly Quota</span>
                 <span className="text-sm font-bold text-[#1f2328]">
-                  {analysis.quotaBreakdown.mixed
-                    ? 'Mixed'
-                    : planInfo[selectedPlan].monthlyQuota
-                  }
+                  {monthlyQuotaDisplay}
                 </span>
               </div>
 

--- a/src/components/ModelUsageTrendsOverview.tsx
+++ b/src/components/ModelUsageTrendsOverview.tsx
@@ -5,6 +5,8 @@ import React, { useMemo } from 'react';
 import { PRICING } from '@/constants/pricing';
 import { useAnalysisContext } from '@/context/AnalysisContext';
 import { ModelDailyStackedChart } from '@/components/charts/ModelDailyStackedChart';
+import type { ModelDailyDatum } from '@/components/charts/ModelDailyStackedChart';
+import type { ProcessedData } from '@/types/csv';
 import { filterDailySeriesByMonths } from '@/utils/analytics/filters';
 import { formatCurrency } from '@/utils/formatters';
 import { buildDailyModelUsageFromArtifacts } from '@/utils/ingestion/analytics';
@@ -24,10 +26,74 @@ function getEffectiveAicQuantity(aicQuantity: number, aicGrossAmount: number): n
   return Math.max(aicQuantity, quantityDerivedFromGross);
 }
 
+function enumerateDateKeys(start: string, end: string): string[] {
+  const dates: string[] = [];
+  const current = new Date(`${start}T00:00:00Z`);
+  const last = new Date(`${end}T00:00:00Z`);
+
+  while (current.getTime() <= last.getTime()) {
+    dates.push(current.toISOString().slice(0, 10));
+    current.setUTCDate(current.getUTCDate() + 1);
+  }
+
+  return dates;
+}
+
+function buildDailyModelBillingQuantity(rows: ProcessedData[]): { data: ModelDailyDatum[]; models: string[] } {
+  const usageRows = rows.filter((row) => !row.isNonCopilotUsage && row.usageUnit === 'ai_credit');
+  if (usageRows.length === 0) {
+    return { data: [], models: [] };
+  }
+
+  const models = Array.from(new Set(usageRows.map((row) => row.model))).sort();
+  const sortedDates = usageRows.map((row) => row.dateKey).sort();
+  const dates = enumerateDateKeys(sortedDates[0], sortedDates[sortedDates.length - 1]);
+  const byDateModel = new Map<string, Map<string, number>>();
+
+  for (const row of usageRows) {
+    const dayMap = byDateModel.get(row.dateKey) ?? new Map<string, number>();
+    dayMap.set(row.model, (dayMap.get(row.model) ?? 0) + (row.billingQuantity ?? row.requestsUsed));
+    byDateModel.set(row.dateKey, dayMap);
+  }
+
+  return {
+    models,
+    data: dates.map((date) => {
+      const dayMap = byDateModel.get(date);
+      const datum: ModelDailyDatum = { date, totalRequests: 0 };
+      let dayTotal = 0;
+
+      for (const model of models) {
+        const value = dayMap?.get(model) ?? 0;
+        datum[model] = value;
+        dayTotal += value;
+      }
+
+      datum.totalRequests = dayTotal;
+      return datum;
+    }),
+  };
+}
+
 export function ModelUsageTrendsOverview() {
-  const { usageArtifacts, dailyBucketsArtifacts, selectedMonths, billingArtifacts } = useAnalysisContext();
+  const {
+    usageArtifacts,
+    dailyBucketsArtifacts,
+    selectedMonths,
+    billingArtifacts,
+    aggregateProcessedData,
+  } = useAnalysisContext();
+  const isUsageBasedBilling = useMemo(() => {
+    const hasAiCreditUsage = aggregateProcessedData.some((row) => row.usageUnit === 'ai_credit');
+    const hasRequestUsage = aggregateProcessedData.some((row) => row.usageUnit === 'request' && row.requestsUsed > 0);
+    return hasAiCreditUsage && !hasRequestUsage;
+  }, [aggregateProcessedData]);
 
   const { data, models } = useMemo(() => {
+    if (isUsageBasedBilling) {
+      return buildDailyModelBillingQuantity(aggregateProcessedData);
+    }
+
     // For now, we ignore month filtering at the aggregation level and rely on
     // the existing dateRange from dailyBucketsArtifacts, which is already
     // derived in UTC from the ingested CSV. Future refinement could slice the
@@ -43,7 +109,7 @@ export function ModelUsageTrendsOverview() {
 
     const modelKeys = Object.keys(usageArtifacts.modelTotals).sort();
     return { data: filtered, models: modelKeys };
-  }, [usageArtifacts, dailyBucketsArtifacts, selectedMonths]);
+  }, [aggregateProcessedData, dailyBucketsArtifacts, isUsageBasedBilling, selectedMonths, usageArtifacts]);
 
   const modelColors: Record<string, string> = useMemo(() => {
     return generateModelColors(models);
@@ -93,7 +159,7 @@ export function ModelUsageTrendsOverview() {
       <div>
         <h2 className="text-2xl font-semibold tracking-tight text-[#1f2328]">Model Usage Trends</h2>
         <p className="text-sm text-[#636c76] mt-1">
-          Daily stacked view by model (UTC)
+          {isUsageBasedBilling ? 'Daily stacked AI Credits by model (UTC)' : 'Daily stacked request view by model (UTC)'}
         </p>
       </div>
 
@@ -142,7 +208,12 @@ export function ModelUsageTrendsOverview() {
           <p className="text-sm text-[#636c76]">No model usage data available for the selected period.</p>
         ) : (
           <div className="h-80 2xl:h-96">
-            <ModelDailyStackedChart data={data} models={models} modelColors={modelColors} />
+            <ModelDailyStackedChart
+              data={data}
+              models={models}
+              modelColors={modelColors}
+              valueUnitLabel={isUsageBasedBilling ? 'AI Credits' : undefined}
+            />
           </div>
         )}
       </div>

--- a/src/components/OrganizationsOverview.tsx
+++ b/src/components/OrganizationsOverview.tsx
@@ -2,6 +2,7 @@
 
 import { BillingGroupEntry, BillingGroupRow, BillingGroupTable, useBillingGroupRows } from '@/components/BillingGroupTable';
 import { useAnalysisContext } from '@/context/AnalysisContext';
+import { getBillingCostLabels } from '@/utils/billingLabels';
 import { UNASSIGNED_BILLING_GROUP } from '@/utils/ingestion';
 
 interface OrganizationRow extends BillingGroupRow {
@@ -26,6 +27,11 @@ export function OrganizationsOverview() {
 
   const hasCosts = orgRows.some(r => r.gross > 0 || r.net > 0);
   const hasAicGross = billingArtifacts?.hasAnyAicData === true;
+  const hasAiCreditUsage = aggregateProcessedData.some((row) => row.usageUnit === 'ai_credit');
+  const hasRequestUsage = aggregateProcessedData.some((row) => row.usageUnit === 'request' && row.requestsUsed > 0);
+  const isUsageBasedBilling = hasAiCreditUsage && !hasRequestUsage;
+  const quantityColumnLabel = isUsageBasedBilling ? 'AI Credits' : 'Requests';
+  const costLabels = getBillingCostLabels(isUsageBasedBilling);
 
   return (
     <BillingGroupTable<OrganizationRow>
@@ -34,8 +40,12 @@ export function OrganizationsOverview() {
       nameColumnLabel="Organization"
       rows={orgRows}
       hasCosts={hasCosts}
-      hasAicGross={hasAicGross}
+      hasAicGross={hasAicGross && !isUsageBasedBilling}
       detailIdPrefix="organization-details"
+      quantityColumnLabel={quantityColumnLabel}
+      grossColumnLabel={costLabels.gross}
+      discountColumnLabel={costLabels.discount}
+      netColumnLabel={costLabels.net}
       extraColumns={[
         {
           key: 'users',

--- a/src/components/UserDetailsView.tsx
+++ b/src/components/UserDetailsView.tsx
@@ -6,6 +6,7 @@ import { COST_OPTIMIZATION_THRESHOLDS, PRICING } from '@/constants/pricing';
 import { AnalysisContext } from '@/context/AnalysisContext';
 import { UserDailyStackedChart } from '@/components/charts/UserDailyStackedChart';
 import type { ProcessedData, UserDailyData } from '@/types/csv';
+import { getQuotaTier, isLegacyPremiumRequestQuotaValue } from '@/utils/analytics/quota';
 import {
   buildUserDailyModelDataFromArtifacts,
   DailyBucketsArtifacts,
@@ -16,6 +17,7 @@ import {
 import { hasAicFields } from '@/utils/aicFields';
 import { generateModelColors } from '@/utils/modelColors';
 import { calculateEnterpriseUpgradeSavings } from '@/utils/analytics/costOptimization';
+import { getBillingCostLabels } from '@/utils/billingLabels';
 import { formatCurrency } from '@/utils/formatters';
 import { aggregateProductCosts } from '@/utils/productCosts';
 import {
@@ -164,6 +166,21 @@ export function UserDetailsView({
   }, [processedData, user, usageArtifacts, dailyBucketsArtifacts]);
 
   const userData = useMemo(() => getUserData(processedData, user), [processedData, user]);
+  const hasUserAiCreditUsage = useMemo(() => userData.some((row) => row.usageUnit === 'ai_credit'), [userData]);
+  const hasUserRequestUsage = useMemo(
+    () => userData.some((row) => row.usageUnit === 'request' && row.requestsUsed > 0),
+    [userData]
+  );
+  const isUserUsageBasedBilling = hasUserAiCreditUsage && !hasUserRequestUsage;
+  const userQuantityColumnLabel = isUserUsageBasedBilling ? 'AI Credits' : 'Requests';
+  const userCostLabels = useMemo(
+    () => getBillingCostLabels(isUserUsageBasedBilling),
+    [isUserUsageBasedBilling]
+  );
+  const userBillingQuantity = useMemo(
+    () => userData.reduce((total, row) => total + (row.billingQuantity ?? row.requestsUsed), 0),
+    [userData]
+  );
 
   const { organization, costCenter } = useMemo(
     () => getUserOrgMetadata(processedData, user),
@@ -184,7 +201,10 @@ export function UserDetailsView({
     return calculateUserTotalRequests(processedData, user);
   }, [processedData, user, usageArtifacts]);
 
-  const effectiveQuota = effectiveUserQuotaValue === 'unknown' ? Infinity : effectiveUserQuotaValue;
+  const requestQuotaValue = isLegacyPremiumRequestQuotaValue(effectiveUserQuotaValue)
+    ? effectiveUserQuotaValue
+    : 'unknown';
+  const effectiveQuota = requestQuotaValue === 'unknown' ? Infinity : requestQuotaValue;
   const billedOverage = useMemo(() => calculateBilledOverageFromRows(userData), [userData]);
   const estimatedOverageRequests = useMemo(
     () => calculateOverageRequests(userTotalRequests, effectiveQuota),
@@ -227,6 +247,7 @@ export function UserDetailsView({
   };
 
   const hasAicGross = useMemo(() => hasAicFields(userData), [userData]);
+  const showAicGross = hasAicGross && !isUserUsageBasedBilling;
 
   const dailyBreakdownRows = useMemo((): DailyModelRow[] => {
     const hasBillingData = userData.some(
@@ -243,9 +264,10 @@ export function UserDetailsView({
     const agg = new Map<Key, { date: string; model: string; requests: number; gross: number; discount: number; net: number; aicGrossAmount: number }>();
     for (const row of userData) {
       const key = `${row.dateKey}||${row.model}`;
+      const quantity = isUserUsageBasedBilling ? row.billingQuantity ?? row.requestsUsed : row.requestsUsed;
       const existing = agg.get(key);
       if (existing) {
-        existing.requests += row.requestsUsed;
+        existing.requests += quantity;
         existing.gross += row.grossAmount ?? 0;
         existing.discount += row.discountAmount ?? 0;
         existing.net += row.netAmount ?? 0;
@@ -254,7 +276,7 @@ export function UserDetailsView({
         agg.set(key, {
           date: row.dateKey,
           model: row.model,
-          requests: row.requestsUsed,
+          requests: quantity,
           gross: row.grossAmount ?? 0,
           discount: row.discountAmount ?? 0,
           net: row.netAmount ?? 0,
@@ -278,7 +300,7 @@ export function UserDetailsView({
       if (isFirst) seenDates.add(r.date);
       return { ...r, isFirstInDate: isFirst, rowSpan: dateSpan.get(r.date) ?? 1 };
     });
-  }, [userData]);
+  }, [isUserUsageBasedBilling, userData]);
 
   const productCosts = useMemo(() => {
     const hasBillingData = userData.some(
@@ -301,10 +323,11 @@ export function UserDetailsView({
     if (effectiveUserQuotaValue === 'unknown') {
       return 'unknown';
     }
-    if (effectiveUserQuotaValue === PRICING.BUSINESS_QUOTA) {
+    const tier = getQuotaTier(effectiveUserQuotaValue);
+    if (tier === 'business') {
       return 'business';
     }
-    if (effectiveUserQuotaValue === PRICING.ENTERPRISE_QUOTA) {
+    if (tier === 'enterprise') {
       return 'enterprise';
     }
 
@@ -369,9 +392,11 @@ export function UserDetailsView({
             {organization ? ` • ${organization}` : ''}
             {costCenter ? ` • ${costCenter}` : ''}
             {' • '}
-            {userTotalRequests.toFixed(1)} / {effectiveUserQuotaValue === 'unknown' ? 'Unknown' : effectiveUserQuotaValue} PRUs consumed
+            {hasUserAiCreditUsage && !hasUserRequestUsage
+              ? `${userBillingQuantity.toFixed(1)} AI Credits consumed`
+              : `${userTotalRequests.toFixed(1)} / ${requestQuotaValue === 'unknown' ? 'Unknown' : requestQuotaValue} PRUs consumed`}
           </p>
-          {overageRequests > 0 && effectiveUserQuotaValue !== 'unknown' && (
+          {overageRequests > 0 && requestQuotaValue !== 'unknown' && (
             <p className="text-sm text-red-600 font-medium" role="alert">
               Overage: {overageRequests.toFixed(1)} PRUs · {formatCurrency(overageCost)}
             </p>
@@ -407,13 +432,13 @@ export function UserDetailsView({
               <thead>
                 <tr className="border-b border-[#d1d9e0]">
                   <th className="px-5 py-3 text-left text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">Product</th>
-                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">Requests</th>
-                  {hasAicGross && (
+                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">{userQuantityColumnLabel}</th>
+                  {showAicGross && (
                     <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">AI Credits Gross</th>
                   )}
-                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">Gross</th>
-                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">Discount</th>
-                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">Net</th>
+                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">{userCostLabels.gross}</th>
+                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">{userCostLabels.discount}</th>
+                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">{userCostLabels.net}</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-[#d1d9e0]">
@@ -421,7 +446,7 @@ export function UserDetailsView({
                   <tr key={product.label} className="hover:bg-[#fcfdff] transition-colors">
                     <td className="px-5 py-3 text-sm font-medium text-[#1f2328]">{product.label}</td>
                     <td className="px-5 py-3 text-sm text-[#636c76] text-right font-mono">{product.requests.toFixed(2)}</td>
-                    {hasAicGross && (
+                    {showAicGross && (
                       <td className="px-5 py-3 text-sm text-[#636c76] text-right font-mono">{formatCurrency(product.aicGrossAmount)}</td>
                     )}
                     <td className="px-5 py-3 text-sm text-[#636c76] text-right font-mono">{formatCurrency(product.gross)}</td>
@@ -449,7 +474,7 @@ export function UserDetailsView({
                 data={userDailyData}
                 models={userModels}
                 modelColors={modelColors}
-                quotaValue={effectiveUserQuotaValue}
+                quotaValue={requestQuotaValue}
                 tooltip={<UserDailyUsageTooltip />}
               />
             </div>
@@ -495,13 +520,13 @@ export function UserDetailsView({
                 <tr className="border-b border-[#d1d9e0]">
                   <th className="px-5 py-3 w-28 text-left text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa] whitespace-nowrap">Date</th>
                   <th className="px-5 py-3 text-left text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">Model</th>
-                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa] whitespace-nowrap">Requests</th>
-                  {hasAicGross && (
+                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa] whitespace-nowrap">{userQuantityColumnLabel}</th>
+                  {showAicGross && (
                     <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa] whitespace-nowrap">AI Credits Gross</th>
                   )}
-                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa] whitespace-nowrap">Gross Cost</th>
-                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa] whitespace-nowrap">Discounts</th>
-                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa] whitespace-nowrap">Net Cost</th>
+                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa] whitespace-nowrap">{userCostLabels.gross}</th>
+                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa] whitespace-nowrap">{userCostLabels.discountSummary}</th>
+                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa] whitespace-nowrap">{userCostLabels.netSummary}</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-[#d1d9e0]">
@@ -517,7 +542,7 @@ export function UserDetailsView({
                     ) : null}
                     <td className="px-5 py-3 text-sm text-[#636c76]">- {row.model}</td>
                     <td className="px-5 py-3 text-sm font-mono text-[#1f2328] text-right">{row.requests.toFixed(2)}</td>
-                    {hasAicGross && (
+                    {showAicGross && (
                       <td className="px-5 py-3 text-sm font-mono text-[#636c76] text-right">{formatCurrency(row.aicGrossAmount)}</td>
                     )}
                     <td className="px-5 py-3 text-sm font-mono text-[#636c76] text-right">{formatCurrency(row.gross)}</td>

--- a/src/components/UsersOverview.tsx
+++ b/src/components/UsersOverview.tsx
@@ -3,6 +3,8 @@
 import { useState, useMemo, useCallback } from 'react';
 
 import { PRICING } from '@/constants/pricing';
+import { getQuotaTier, isLegacyPremiumRequestQuotaValue } from '@/utils/analytics/quota';
+import { getBillingCostLabels } from '@/utils/billingLabels';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useSortableTable } from '@/hooks/useSortableTable';
 import { ProcessedData } from '@/types/csv';
@@ -21,6 +23,13 @@ import { UserDetailsView } from './UserDetailsView';
 
 type DailyCumulativeData = { date: string; [user: string]: string | number };
 const ALL_FILTERS_VALUE = '__all__';
+
+function getPlanDisplayName(quotaValue: number | 'unknown' | undefined): string {
+  const tier = getQuotaTier(quotaValue);
+  if (tier === 'business') return 'Business';
+  if (tier === 'enterprise') return 'Enterprise';
+  return 'Unknown';
+}
 
 function formatUserCount(count: number): string {
   return `${count} ${count === 1 ? 'user' : 'users'}`;
@@ -66,13 +75,21 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, qu
   }, [userCosts]);
 
   const hasAicGross = effectiveBillingArtifacts.hasAnyAicData;
+  const isUsageBasedBilling = useMemo(() => {
+    const hasAiCreditUsage = processedData.some((row) => row.usageUnit === 'ai_credit');
+    const hasRequestUsage = processedData.some((row) => row.usageUnit === 'request' && row.requestsUsed > 0);
+    return hasAiCreditUsage && !hasRequestUsage;
+  }, [processedData]);
+  const showRequestMetrics = !isUsageBasedBilling;
+  const showAicGross = hasAicGross && !isUsageBasedBilling;
+  const costLabels = useMemo(() => getBillingCostLabels(isUsageBasedBilling), [isUsageBasedBilling]);
 
   const columns = useMemo<ColumnKey[]>(() => [
     'quota',
-    'totalRequests',
-    ...(hasAicGross ? ['aicGrossAmount'] as ColumnKey[] : []),
+    ...(showRequestMetrics ? ['totalRequests'] as ColumnKey[] : []),
+    ...(showAicGross ? ['aicGrossAmount'] as ColumnKey[] : []),
     ...(hasCosts ? ['gross', 'discount', 'net'] as ColumnKey[] : [])
-  ], [hasAicGross, hasCosts]);
+  ], [hasCosts, showAicGross, showRequestMetrics]);
 
   const getSortableValue = useCallback((row: UserSummary, column: ColumnKey) => {
     if (column === 'quota') {
@@ -105,10 +122,15 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, qu
 
   const getUserPlanLabel = useCallback((user: string): string | null => {
     const q = getUserQuota(quotaArtifacts, user);
-    if (q === PRICING.ENTERPRISE_QUOTA) return 'Copilot Enterprise';
-    if (q === PRICING.BUSINESS_QUOTA) return 'Copilot Business';
+    const tier = getQuotaTier(q);
+    if (tier === 'enterprise') return 'Copilot Enterprise';
+    if (tier === 'business') return 'Copilot Business';
     return null;
   }, [quotaArtifacts]);
+
+  const getUserPlanDisplayName = useCallback((user: string): string => (
+    getPlanDisplayName(getUserQuota(quotaArtifacts, user))
+  ), [quotaArtifacts]);
 
   const planOptions = useMemo(() => {
     const plans = new Set<string>();
@@ -125,9 +147,10 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, qu
 
     for (const user of userData) {
       const quota = getUserQuota(quotaArtifacts, user.user);
-      if (quota === PRICING.BUSINESS_QUOTA) {
+      const tier = getQuotaTier(quota);
+      if (tier === 'business') {
         businessUsers += 1;
-      } else if (quota === PRICING.ENTERPRISE_QUOTA) {
+      } else if (tier === 'enterprise') {
         enterpriseUsers += 1;
       }
     }
@@ -173,7 +196,7 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, qu
     data: filteredUserData,
     columns,
     getSortableValue,
-    defaultSort: { column: 'totalRequests', direction: 'desc' }
+    defaultSort: { column: showRequestMetrics ? 'totalRequests' : hasCosts ? 'gross' : 'quota', direction: 'desc' }
   });
   
   const filteredUsageArtifacts = useMemo(() => {
@@ -191,7 +214,7 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, qu
     const quotaTypes = new Set<number>();
     filteredUserData.forEach(user => {
       const userQuota = getUserQuota(quotaArtifacts, user.user);
-      if (userQuota !== 'unknown') {
+      if (isLegacyPremiumRequestQuotaValue(userQuota)) {
         quotaTypes.add(userQuota);
       }
     });
@@ -403,6 +426,7 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, qu
                 currentQuota={currentQuota}
                 quotaTypes={quotaTypes}
                 hasMixedQuotas={hasMixedQuotas}
+                showQuotaReference={quotaTypes.size > 0}
               />
             </div>
           </div>
@@ -424,9 +448,10 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, qu
             <div className="p-4 space-y-2 sm:hidden">
               {paginatedUserData.map((user) => {
                 const userQuota = getUserQuota(quotaArtifacts, user.user);
-                const isOverQuota = userQuota !== 'unknown' && user.totalRequests > userQuota;
+                const isOverQuota = isLegacyPremiumRequestQuotaValue(userQuota) && user.totalRequests > userQuota;
                 const quotaDisplay = userQuota === 'unknown' ? 'Unknown' : `${userQuota}`;
                 const costs = userCosts.get(user.user);
+                const planDisplay = getUserPlanDisplayName(user.user);
 
                 return (
                 <button
@@ -438,18 +463,26 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, qu
                     <span className="font-medium text-[#1f2328] truncate flex-1 mr-2">
                       {user.user}
                     </span>
-                    <span className={`text-sm font-mono ${isOverQuota ? 'text-red-600' : 'text-[#1f2328]'}`}>
-                      {user.totalRequests.toFixed(1)}
-                    </span>
-                  </div>
-                  <div className="text-xs text-[#636c76]">
-                    Quota: {quotaDisplay}
-                    {isOverQuota && (
-                      <span className="text-red-500 ml-2">
-                        +{(user.totalRequests - (userQuota as number)).toFixed(1)} over
+                    {showRequestMetrics ? (
+                      <span className={`text-sm font-mono ${isOverQuota ? 'text-red-600' : 'text-[#1f2328]'}`}>
+                        {user.totalRequests.toFixed(1)}
+                      </span>
+                    ) : (
+                      <span className="text-sm font-medium text-[#636c76]">
+                        {planDisplay}
                       </span>
                     )}
                   </div>
+                  {showRequestMetrics && (
+                    <div className="text-xs text-[#636c76]">
+                      Quota: {quotaDisplay}
+                      {isOverQuota && (
+                        <span className="text-red-500 ml-2">
+                          +{(user.totalRequests - (userQuota as number)).toFixed(1)} over
+                        </span>
+                      )}
+                    </div>
+                  )}
                   {hasCosts && ((costs?.gross ?? 0) > 0 || (costs?.discount ?? 0) > 0 || (costs?.net ?? 0) > 0) && (
                     <div className="flex items-center gap-3 mt-1.5 text-xs font-mono tabular-nums">
                       <span className="text-[#636c76]">{formatCurrency(costs?.gross ?? 0)}</span>
@@ -457,7 +490,7 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, qu
                       <span className="font-semibold text-[#1f2328]">{formatCurrency(costs?.net ?? 0)}</span>
                     </div>
                   )}
-                  {hasAicGross && (
+                  {showAicGross && (
                     <div className="mt-1.5 text-xs font-mono tabular-nums text-[#636c76]">
                       AI Credits Gross: {formatCurrency(costs?.aicGrossAmount ?? 0)}
                     </div>
@@ -505,26 +538,28 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, qu
                   onClick={() => handleSortWithReset('quota')}
                 >
                   <div className="flex items-center gap-1 justify-end">
-                    Quota
+                    {isUsageBasedBilling ? 'Plan' : 'Quota'}
                     <span className="text-[#636c76]">
                       {sortBy === 'quota' ? (sortDirection === 'desc' ? '↓' : '↑') : '↕'}
                     </span>
                   </div>
                 </th>
-                <th
-                  className={`px-4 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-[0.05em] min-w-32 cursor-pointer hover:bg-[#f6f8fa] select-none transition-colors duration-150 ${
-                    sortBy === 'totalRequests' ? 'bg-[#f6f8fa]' : 'bg-[#f6f8fa]'
-                  }`}
-                  onClick={() => handleSortWithReset('totalRequests')}
-                >
-                  <div className="flex items-center gap-1 justify-end">
-                    Total Requests
-                    <span className="text-[#636c76]">
-                      {sortBy === 'totalRequests' ? (sortDirection === 'desc' ? '↓' : '↑') : '↕'}
-                    </span>
-                  </div>
-                </th>
-                {hasAicGross && (
+                {showRequestMetrics && (
+                  <th
+                    className={`px-4 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-[0.05em] min-w-32 cursor-pointer hover:bg-[#f6f8fa] select-none transition-colors duration-150 ${
+                      sortBy === 'totalRequests' ? 'bg-[#f6f8fa]' : 'bg-[#f6f8fa]'
+                    }`}
+                    onClick={() => handleSortWithReset('totalRequests')}
+                  >
+                    <div className="flex items-center gap-1 justify-end">
+                      Total Requests
+                      <span className="text-[#636c76]">
+                        {sortBy === 'totalRequests' ? (sortDirection === 'desc' ? '↓' : '↑') : '↕'}
+                      </span>
+                    </div>
+                  </th>
+                )}
+                {showAicGross && (
                   <th
                     className={`px-4 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-[0.05em] min-w-36 cursor-pointer hover:bg-[#f6f8fa] select-none transition-colors duration-150 ${
                       sortBy === 'aicGrossAmount' ? 'bg-[#eef1f4]' : 'bg-[#f6f8fa]'
@@ -548,7 +583,7 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, qu
                       onClick={() => handleSortWithReset('gross')}
                     >
                       <div className="flex items-center gap-1 justify-end">
-                        Gross
+                        {costLabels.gross}
                         <span className="text-[#636c76]">
                           {sortBy === 'gross' ? (sortDirection === 'desc' ? '↓' : '↑') : '↕'}
                         </span>
@@ -561,7 +596,7 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, qu
                       onClick={() => handleSortWithReset('discount')}
                     >
                       <div className="flex items-center gap-1 justify-end">
-                        Discount
+                        {costLabels.discount}
                         <span className="text-[#636c76]">
                           {sortBy === 'discount' ? (sortDirection === 'desc' ? '↓' : '↑') : '↕'}
                         </span>
@@ -574,7 +609,7 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, qu
                       onClick={() => handleSortWithReset('net')}
                     >
                       <div className="flex items-center gap-1 justify-end">
-                        Net
+                        {costLabels.net}
                         <span className="text-[#636c76]">
                           {sortBy === 'net' ? (sortDirection === 'desc' ? '↓' : '↑') : '↕'}
                         </span>
@@ -587,8 +622,9 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, qu
             <tbody className="divide-y divide-[#f6f8fa]">
               {paginatedUserData.map((user) => {
                 const userQuota = getUserQuota(quotaArtifacts, user.user);
-                const isOverQuota = userQuota !== 'unknown' && user.totalRequests > userQuota;
+                const isOverQuota = isLegacyPremiumRequestQuotaValue(userQuota) && user.totalRequests > userQuota;
                 const quotaDisplay = userQuota === 'unknown' ? 'Unknown' : userQuota.toString();
+                const planDisplay = getUserPlanDisplayName(user.user);
 
                 return (
                 <tr key={user.user} className="hover:bg-[#fcfdff] transition-colors duration-150">
@@ -601,24 +637,26 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, qu
                       {user.user}
                     </button>
                   </td>
-                  <td className="px-4 py-3 whitespace-nowrap text-sm text-[#636c76] font-mono tabular-nums text-right">
-                    {quotaDisplay}
+                  <td className={`px-4 py-3 whitespace-nowrap text-sm text-[#636c76] text-right ${isUsageBasedBilling ? 'font-medium' : 'font-mono tabular-nums'}`}>
+                    {isUsageBasedBilling ? planDisplay : quotaDisplay}
                   </td>
-                  <td className={`px-4 py-3 whitespace-nowrap text-sm font-mono font-medium tabular-nums text-right ${
-                    isOverQuota ? 'text-red-600' : 'text-[#1f2328]'
-                  }`}>
-                    {user.totalRequests.toFixed(2)}
-                    {isOverQuota && (
-                      <span className="ml-1.5 text-xs text-red-500 font-normal">
-                        (+{(user.totalRequests - (userQuota as number)).toFixed(1)})
-                      </span>
-                    )}
-                  </td>
+                  {showRequestMetrics && (
+                    <td className={`px-4 py-3 whitespace-nowrap text-sm font-mono font-medium tabular-nums text-right ${
+                      isOverQuota ? 'text-red-600' : 'text-[#1f2328]'
+                    }`}>
+                      {user.totalRequests.toFixed(2)}
+                      {isOverQuota && (
+                        <span className="ml-1.5 text-xs text-red-500 font-normal">
+                          (+{(user.totalRequests - (userQuota as number)).toFixed(1)})
+                        </span>
+                      )}
+                    </td>
+                  )}
                   {(() => {
                     const costs = userCosts.get(user.user);
                     return (
                       <>
-                        {hasAicGross && (
+                        {showAicGross && (
                           <td className="px-4 py-3 whitespace-nowrap text-sm text-[#636c76] font-mono tabular-nums text-right">
                             {formatCurrency(costs?.aicGrossAmount ?? 0)}
                           </td>

--- a/src/components/charts/ModelDailyStackedChart.tsx
+++ b/src/components/charts/ModelDailyStackedChart.tsx
@@ -17,9 +17,16 @@ export interface ModelDailyStackedChartProps {
   models: string[];
   modelColors: Record<string, string>;
   height?: ResponsiveHeight;
+  valueUnitLabel?: string;
 }
 
-export function ModelDailyStackedChart({ data, models, modelColors, height = '100%' }: ModelDailyStackedChartProps) {
+export function ModelDailyStackedChart({
+  data,
+  models,
+  modelColors,
+  height = '100%',
+  valueUnitLabel,
+}: ModelDailyStackedChartProps) {
   return (
     <ResponsiveContainer width="100%" height={height}>
       <BarChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
@@ -34,7 +41,10 @@ export function ModelDailyStackedChart({ data, models, modelColors, height = '10
           contentStyle={chartTooltipContentStyle}
           labelStyle={chartTooltipLabelStyle}
           labelFormatter={(value) => value as string}
-          formatter={(value, name) => [Number(value).toFixed(2), String(name)]}
+          formatter={(value, name) => [
+            valueUnitLabel ? `${Number(value).toFixed(2)} ${valueUnitLabel}` : Number(value).toFixed(2),
+            String(name),
+          ]}
           wrapperStyle={{ zIndex: 1000 }}
         />
         <Legend wrapperStyle={{ fontSize: 12, color: '#636c76' }} />

--- a/src/components/charts/ModelRequestsBarChart.tsx
+++ b/src/components/charts/ModelRequestsBarChart.tsx
@@ -17,10 +17,17 @@ type ResponsiveHeight = number | `${number}%`;
 interface ModelRequestsBarChartProps {
   data: ModelRequestsBarChartDatum[];
   height?: ResponsiveHeight;
+  valueLabel?: string;
+  valueUnitLabel?: string;
 }
 
 // Extracted from DataAnalysis overview section to standardize chart usage
-export function ModelRequestsBarChart({ data, height = '100%' as ResponsiveHeight }: ModelRequestsBarChartProps) {
+export function ModelRequestsBarChart({
+  data,
+  height = '100%' as ResponsiveHeight,
+  valueLabel = 'Total Requests',
+  valueUnitLabel = 'requests',
+}: ModelRequestsBarChartProps) {
   return (
     <ResponsiveContainer width="100%" height={height}>
       <BarChart
@@ -44,8 +51,8 @@ export function ModelRequestsBarChart({ data, height = '100%' as ResponsiveHeigh
         />
         <Tooltip 
           formatter={(value) => [
-            `${Number(value).toLocaleString()} requests`,
-            'Total Requests'
+            `${Number(value).toLocaleString()} ${valueUnitLabel}`,
+            valueLabel
           ]}
           labelFormatter={(label, payload) => {
             const item = payload?.[0]?.payload as ModelRequestsBarChartDatum | undefined;

--- a/src/components/charts/UsersAicClustersChart.tsx
+++ b/src/components/charts/UsersAicClustersChart.tsx
@@ -155,7 +155,7 @@ export function UsersAicClustersChart({ users }: UsersAicClustersChartProps) {
             <XAxis
               type="number"
               dataKey="averageRequests"
-              name="Avg premium requests"
+              name="Avg usage quantity"
               tick={{ fontSize: 12, fill: '#636c76' }}
               axisLine={{ stroke: '#d1d9e0' }}
               tickLine={{ stroke: '#d1d9e0' }}
@@ -177,7 +177,7 @@ export function UsersAicClustersChart({ users }: UsersAicClustersChartProps) {
               labelStyle={chartTooltipLabelStyle}
               formatter={(value, name) => {
                 if (name === 'Avg AI Credits gross') return [formatCurrency(Number(value)), name];
-                if (name === 'Avg premium requests') return [Number(value).toFixed(1), name];
+                if (name === 'Avg usage quantity') return [Number(value).toFixed(1), name];
                 return [Number(value).toLocaleString(), name];
               }}
             />
@@ -208,7 +208,7 @@ export function UsersAicClustersChart({ users }: UsersAicClustersChartProps) {
                 Total AIC Gross
               </th>
               <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
-                Avg Requests
+                Avg Usage Quantity
               </th>
               <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
                 AIC Share

--- a/src/components/charts/UsersConsumptionHeatmap.tsx
+++ b/src/components/charts/UsersConsumptionHeatmap.tsx
@@ -9,6 +9,7 @@ export interface UsersConsumptionHeatmapProps {
   currentQuota: number;
   quotaTypes: Set<number>;
   hasMixedQuotas: boolean;
+  showQuotaReference?: boolean;
 }
 
 interface HeatmapCell {
@@ -73,7 +74,8 @@ export function UsersConsumptionHeatmap({
   users,
   currentQuota,
   quotaTypes,
-  hasMixedQuotas
+  hasMixedQuotas,
+  showQuotaReference = true
 }: UsersConsumptionHeatmapProps) {
   const { heatmapData, maxConsumption, binSize } = useMemo(() => {
     let maxValue = currentQuota * 1.2;
@@ -154,6 +156,10 @@ export function UsersConsumptionHeatmap({
   const quotaLineYPositions = useMemo(() => {
     const lines: Array<{ y: number; label: string; color: string }> = [];
     
+    if (!showQuotaReference) {
+      return lines;
+    }
+
     if (hasMixedQuotas) {
       if (quotaTypes.has(PRICING.BUSINESS_QUOTA)) {
         const binIndex = (PRICING.BUSINESS_QUOTA / maxConsumption) * CONSUMPTION_BINS;
@@ -181,7 +187,7 @@ export function UsersConsumptionHeatmap({
     }
     
     return lines;
-  }, [hasMixedQuotas, quotaTypes, currentQuota, maxConsumption, chartHeight]);
+  }, [hasMixedQuotas, quotaTypes, currentQuota, maxConsumption, chartHeight, showQuotaReference]);
 
   return (
     <div className="w-full h-full">

--- a/src/components/charts/UsersQuotaConsumptionChart.tsx
+++ b/src/components/charts/UsersQuotaConsumptionChart.tsx
@@ -15,6 +15,7 @@ export interface UsersQuotaConsumptionChartProps {
   quotaTypes: Set<number>;
   hasMixedQuotas: boolean;
   hasMixedLicenses: boolean;
+  showQuotaReference?: boolean;
 }
 
 export function UsersQuotaConsumptionChart({
@@ -24,7 +25,8 @@ export function UsersQuotaConsumptionChart({
   currentQuota,
   quotaTypes,
   hasMixedQuotas,
-  hasMixedLicenses
+  hasMixedLicenses,
+  showQuotaReference = true
 }: UsersQuotaConsumptionChartProps) {
   return (
     <ResponsiveContainer width="100%" height="100%">
@@ -53,7 +55,7 @@ export function UsersQuotaConsumptionChart({
           wrapperStyle={{ zIndex: 1000 }}
         />
         {/* Quota reference lines */}
-        {hasMixedQuotas ? (
+        {showQuotaReference && (hasMixedQuotas ? (
           <>
             {quotaTypes.has(PRICING.BUSINESS_QUOTA) && (
               <ReferenceLine 
@@ -82,7 +84,7 @@ export function UsersQuotaConsumptionChart({
             strokeDasharray="5 5"
             label={{ value: `${currentQuota} quota limit`, position: "insideTopRight" }}
           />
-        )}
+        ))}
         {/* User lines */}
         {users.map((user) => (
           <Line

--- a/src/constants/pricing.ts
+++ b/src/constants/pricing.ts
@@ -3,17 +3,29 @@ export const PRICING = {
   AI_CREDIT_USD_VALUE: 0.01,
   BUSINESS_AI_CREDITS_INCLUDED: 3000,
   ENTERPRISE_AI_CREDITS_INCLUDED: 7000,
+  BUSINESS_AI_CREDIT_QUOTA: 1900,
+  ENTERPRISE_AI_CREDIT_QUOTA: 3900,
   AUTO_MODE_DISCOUNT_RATE: 0.1,
   BUSINESS_QUOTA: 300,
   ENTERPRISE_QUOTA: 1000,
   ENTERPRISE_UPGRADE_DELTA: 20,
 } as const;
 
-// Recognized premium-request quota tiers. Any other numeric quota (e.g. the
-// 2147483647 sentinel emitted for non-billable events) is treated as unknown.
-export const KNOWN_QUOTA_VALUES: readonly number[] = [
+export const BUSINESS_QUOTA_VALUES: readonly number[] = [
   PRICING.BUSINESS_QUOTA,
+  PRICING.BUSINESS_AI_CREDIT_QUOTA,
+];
+
+export const ENTERPRISE_QUOTA_VALUES: readonly number[] = [
   PRICING.ENTERPRISE_QUOTA,
+  PRICING.ENTERPRISE_AI_CREDIT_QUOTA,
+];
+
+// Recognized quota tiers across legacy PRU reports and current AI Credits
+// reports. Any other numeric quota (e.g. non-billable sentinels) is unknown.
+export const KNOWN_QUOTA_VALUES: readonly number[] = [
+  ...BUSINESS_QUOTA_VALUES,
+  ...ENTERPRISE_QUOTA_VALUES,
 ];
 
 // Cost optimization thresholds

--- a/src/types/csv.ts
+++ b/src/types/csv.ts
@@ -38,6 +38,8 @@ export interface ProcessedData {
   product?: string;
   sku?: string;
   unitType?: string;
+  usageUnit?: 'request' | 'ai_credit' | 'unknown';
+  billingQuantity?: number;
   organization?: string;
   costCenter?: string;
   appliedCostPerQuantity?: number;

--- a/src/utils/aicPool.ts
+++ b/src/utils/aicPool.ts
@@ -1,4 +1,5 @@
 import { PRICING } from '@/constants/pricing';
+import { shouldReplaceQuotaValue } from '@/utils/analytics/quota';
 
 interface AicPoolUser {
   user: string;
@@ -13,6 +14,10 @@ export interface AicPoolEstimate {
 }
 
 export function getIncludedAicCreditsForQuota(quotaValue: number | 'unknown' | undefined): number {
+  if (quotaValue === PRICING.BUSINESS_AI_CREDIT_QUOTA || quotaValue === PRICING.ENTERPRISE_AI_CREDIT_QUOTA) {
+    return quotaValue;
+  }
+
   if (quotaValue === PRICING.BUSINESS_QUOTA) {
     return PRICING.BUSINESS_AI_CREDITS_INCLUDED;
   }
@@ -34,11 +39,7 @@ export function calculateIncludedAicCreditsForUsers(users: Iterable<AicPoolUser>
 
     const existingQuota = quotaByUser.get(user.user);
     const currentQuota = user.quotaValue;
-    if (
-      !quotaByUser.has(user.user)
-      || (existingQuota === 'unknown' && typeof currentQuota === 'number')
-      || (typeof currentQuota === 'number' && typeof existingQuota === 'number' && currentQuota > existingQuota)
-    ) {
+    if (!quotaByUser.has(user.user) || shouldReplaceQuotaValue(existingQuota, currentQuota ?? 'unknown')) {
       quotaByUser.set(user.user, currentQuota);
     }
   }

--- a/src/utils/analytics/overage.ts
+++ b/src/utils/analytics/overage.ts
@@ -1,7 +1,7 @@
 import type { ProcessedData } from '@/types/csv';
 import { calculateOverageRequests, calculateOverageCost } from '@/utils/userCalculations';
 
-import { buildUserQuotaMapFromRows } from './quota';
+import { buildUserQuotaMapFromRows, isLegacyPremiumRequestQuotaValue } from './quota';
 import type { UserSummary } from './types';
 
 export interface OverageSummary {
@@ -18,7 +18,10 @@ export function computeOverageSummary(userData: UserSummary[], processedData: Pr
   const quotaMap = buildUserQuotaMapFromRows(processedData);
   const totalOverageRequests = userData.reduce((total, user) => {
     const userQuota = quotaMap.get(user.user) ?? 'unknown';
-    const overage = calculateOverageRequests(user.totalRequests, userQuota);
+    const overage = calculateOverageRequests(
+      user.totalRequests,
+      isLegacyPremiumRequestQuotaValue(userQuota) ? userQuota : 'unknown'
+    );
     return total + overage;
   }, 0);
   const totalOverageCost = calculateOverageCost(totalOverageRequests);

--- a/src/utils/analytics/quota.ts
+++ b/src/utils/analytics/quota.ts
@@ -1,6 +1,6 @@
-import { KNOWN_QUOTA_VALUES, PRICING } from '@/constants/pricing';
+import { BUSINESS_QUOTA_VALUES, ENTERPRISE_QUOTA_VALUES, KNOWN_QUOTA_VALUES, PRICING } from '@/constants/pricing';
 import { ProcessedData } from '@/types/csv';
-import { isRequestUnitType } from '@/utils/unitType';
+import { isRequestUnitType, isSupportedUsageUnitType } from '@/utils/unitType';
 
 export interface QuotaBreakdownResult {
   unknown: string[];
@@ -8,6 +8,51 @@ export interface QuotaBreakdownResult {
   enterprise: string[];
   mixed: boolean;
   suggestedPlan: 'business' | 'enterprise' | null;
+}
+
+export type QuotaTier = 'business' | 'enterprise';
+
+export function getQuotaTier(quotaValue: number | 'unknown' | undefined): QuotaTier | null {
+  if (typeof quotaValue !== 'number') {
+    return null;
+  }
+
+  if (BUSINESS_QUOTA_VALUES.includes(quotaValue)) {
+    return 'business';
+  }
+
+  if (ENTERPRISE_QUOTA_VALUES.includes(quotaValue)) {
+    return 'enterprise';
+  }
+
+  return null;
+}
+
+export function isBusinessQuotaValue(quotaValue: number | 'unknown' | undefined): boolean {
+  return getQuotaTier(quotaValue) === 'business';
+}
+
+export function isEnterpriseQuotaValue(quotaValue: number | 'unknown' | undefined): boolean {
+  return getQuotaTier(quotaValue) === 'enterprise';
+}
+
+export function isKnownQuotaValue(quotaValue: number | 'unknown' | undefined): quotaValue is number {
+  return getQuotaTier(quotaValue) !== null;
+}
+
+export function isLegacyPremiumRequestQuotaValue(quotaValue: number | 'unknown' | undefined): quotaValue is number {
+  return quotaValue === PRICING.BUSINESS_QUOTA || quotaValue === PRICING.ENTERPRISE_QUOTA;
+}
+
+function getQuotaTierRank(quotaValue: number | 'unknown' | undefined): number {
+  const tier = getQuotaTier(quotaValue);
+  if (tier === 'enterprise') {
+    return 2;
+  }
+  if (tier === 'business') {
+    return 1;
+  }
+  return 0;
 }
 
 // Parse quota value from string. Only recognized quota tiers are kept as
@@ -29,22 +74,37 @@ export function shouldReplaceQuotaValue(
   existing: number | 'unknown' | undefined,
   incoming: number | 'unknown'
 ): boolean {
-  return (
-    existing === undefined
-    || (existing === 'unknown' && typeof incoming === 'number')
-    || (typeof incoming === 'number' && typeof existing === 'number' && incoming > existing)
-  );
+  if (existing === undefined) {
+    return true;
+  }
+
+  if (incoming === 'unknown') {
+    return false;
+  }
+
+  if (existing === 'unknown') {
+    return true;
+  }
+
+  const existingRank = getQuotaTierRank(existing);
+  const incomingRank = getQuotaTierRank(incoming);
+
+  if (incomingRank !== existingRank) {
+    return incomingRank > existingRank;
+  }
+
+  return incoming > existing;
 }
 
-/**
- * Build per-user quotas from processed rows using the canonical policy:
- * numeric quotas win over unknown values, and the highest numeric quota wins.
- */
-export function buildUserQuotaMapFromRows(data: ProcessedData[]): Map<string, number | 'unknown'> {
+function buildUserQuotaMap(data: ProcessedData[], includeAiCreditUsage: boolean): Map<string, number | 'unknown'> {
   const userQuotas = new Map<string, number | 'unknown'>();
 
   for (const row of data) {
-    if (row.isNonCopilotUsage || !isRequestUnitType(row.unitType)) {
+    const shouldUseQuota = includeAiCreditUsage
+      ? isSupportedUsageUnitType(row.unitType, row.sku)
+      : isRequestUnitType(row.unitType);
+
+    if (row.isNonCopilotUsage || !shouldUseQuota) {
       continue;
     }
 
@@ -57,6 +117,18 @@ export function buildUserQuotaMapFromRows(data: ProcessedData[]): Map<string, nu
   }
 
   return userQuotas;
+}
+
+/**
+ * Build per-user premium request quotas from processed rows using the canonical
+ * policy: numeric quotas win over unknown values, and the highest tier wins.
+ */
+export function buildUserQuotaMapFromRows(data: ProcessedData[]): Map<string, number | 'unknown'> {
+  return buildUserQuotaMap(data, false);
+}
+
+export function buildUsageQuotaMapFromRows(data: ProcessedData[]): Map<string, number | 'unknown'> {
+  return buildUserQuotaMap(data, true);
 }
 
 /**
@@ -75,9 +147,9 @@ export function classifyQuotaMap(
   for (const [user, quota] of quotaByUser) {
     if (quota === 'unknown') {
       unknown.push(user);
-    } else if (quota === PRICING.BUSINESS_QUOTA) {
+    } else if (isBusinessQuotaValue(quota)) {
       business.push(user);
-    } else if (quota === PRICING.ENTERPRISE_QUOTA) {
+    } else if (isEnterpriseQuotaValue(quota)) {
       enterprise.push(user);
     }
   }
@@ -102,5 +174,5 @@ export function classifyQuotaMap(
 }
 
 export function buildQuotaBreakdown(data: ProcessedData[]): QuotaBreakdownResult {
-  return classifyQuotaMap(buildUserQuotaMapFromRows(data));
+  return classifyQuotaMap(buildUsageQuotaMapFromRows(data));
 }

--- a/src/utils/analytics/transformations.ts
+++ b/src/utils/analytics/transformations.ts
@@ -2,7 +2,7 @@ import { CSVData, ProcessedData, AnalysisResults } from '@/types/csv';
 
 import { buildProcessedDataFromRawRows } from '../ingestion/adapters';
 
-import { buildQuotaBreakdown, buildUserQuotaMapFromRows } from './quota';
+import { buildQuotaBreakdown, buildUserQuotaMapFromRows, isLegacyPremiumRequestQuotaValue } from './quota';
 
 // Re-export for backwards compatibility
 export type { UserSummary } from './types';
@@ -55,7 +55,7 @@ export function analyzeData(data: ProcessedData[]): AnalysisResults {
   });
   for (const [user, totalRequests] of userTotalRequests) {
     const quota = userQuotas.get(user);
-    if (quota && quota !== 'unknown' && totalRequests > quota) {
+    if (isLegacyPremiumRequestQuotaValue(quota) && totalRequests > quota) {
       usersExceedingQuota.add(user);
     }
   }

--- a/src/utils/autoModeSavings.ts
+++ b/src/utils/autoModeSavings.ts
@@ -24,6 +24,10 @@ export function aggregateAutoModeSavings(rows: ProcessedData[]): AutoModeSavings
   const buckets = new Map<string, AutoModeSavingsRow>();
 
   for (const row of rows) {
+    if (row.usageUnit === 'ai_credit') {
+      continue;
+    }
+
     const model = getAutoModeBaseModel(row.model);
 
     if (!model) {

--- a/src/utils/billingLabels.ts
+++ b/src/utils/billingLabels.ts
@@ -1,0 +1,25 @@
+export interface BillingCostLabels {
+  gross: string;
+  discount: string;
+  discountSummary: string;
+  net: string;
+  netSummary: string;
+}
+
+export function getBillingCostLabels(isUsageBasedBilling: boolean): BillingCostLabels {
+  return isUsageBasedBilling
+    ? {
+      gross: 'Gross Amount',
+      discount: 'Included Credits',
+      discountSummary: 'Included credits',
+      net: 'Additional usage',
+      netSummary: 'Additional usage',
+    }
+    : {
+      gross: 'Gross',
+      discount: 'Discount',
+      discountSummary: 'Discounts',
+      net: 'Net',
+      netSummary: 'Net cost',
+    };
+}

--- a/src/utils/ingestion/QuotaAggregator.ts
+++ b/src/utils/ingestion/QuotaAggregator.ts
@@ -3,8 +3,8 @@
  * Eliminates O(U*R) repeated lookups by maintaining O(1) map.
  */
 
-import { shouldReplaceQuotaValue } from '@/utils/analytics/quota';
-import { isRequestUnitType } from '@/utils/unitType';
+import { getQuotaTier, shouldReplaceQuotaValue } from '@/utils/analytics/quota';
+import { isSupportedUsageUnitType } from '@/utils/unitType';
 
 import {
   Aggregator,
@@ -38,7 +38,7 @@ export class QuotaAggregator implements Aggregator<QuotaArtifacts> {
       return;
     }
 
-    if (row.quotaValue === undefined || !isRequestUnitType(row.unitType)) return;
+    if (row.quotaValue === undefined || !isSupportedUsageUnitType(row.unitType, row.sku)) return;
     
     const existing = this.quotaByUser.get(row.user);
     const current = row.quotaValue;
@@ -62,12 +62,15 @@ export class QuotaAggregator implements Aggregator<QuotaArtifacts> {
   }
   
   finalize(ctx: AggregatorContext): QuotaArtifacts {
-    const hasMixedLicenses = this.distinctQuotas.has(ctx.pricing.BUSINESS_QUOTA)
-      && this.distinctQuotas.has(ctx.pricing.ENTERPRISE_QUOTA);
+    const distinctTiers = new Set(
+      Array.from(this.distinctQuotas)
+        .map((quota) => getQuotaTier(quota))
+        .filter((tier): tier is 'business' | 'enterprise' => tier !== null)
+    );
+    const hasMixedLicenses = distinctTiers.has('business') && distinctTiers.has('enterprise');
     
     const hasUnknown = Array.from(this.quotaByUser.values()).includes('unknown');
-    const hasMixedQuotas = this.distinctQuotas.size > 1 
-      || (this.distinctQuotas.size >= 1 && hasUnknown);
+    const hasMixedQuotas = distinctTiers.size > 1 || (distinctTiers.size >= 1 && hasUnknown);
     
     return {
       quotaByUser: this.quotaByUser,

--- a/src/utils/ingestion/adapters.ts
+++ b/src/utils/ingestion/adapters.ts
@@ -55,6 +55,8 @@ export function buildProcessedDataFromRows(
       product: row.product,
       sku: row.sku,
       unitType: row.unitType,
+      usageUnit: row.usageUnit,
+      billingQuantity: row.billingQuantity,
       organization: row.organization,
       costCenter: row.costCenter,
       appliedCostPerQuantity: row.appliedCostPerQuantity,

--- a/src/utils/ingestion/analytics.ts
+++ b/src/utils/ingestion/analytics.ts
@@ -16,7 +16,7 @@ import { CodingAgentAnalysis, UserDailyData } from '@/types/csv';
 import { buildAdvisoriesFromCategories, getEarlyExhausterCount, type Advisory } from '@/utils/analytics/advisory';
 import { CONSUMPTION_THRESHOLDS, UserConsumptionCategory, InsightsOverviewData } from '@/utils/analytics/insights';
 import type { FeatureUtilizationStats } from '@/utils/analytics/insights';
-import { buildUserQuotaMapFromRows, classifyQuotaMap } from '@/utils/analytics/quota';
+import { buildUserQuotaMapFromRows, classifyQuotaMap, isLegacyPremiumRequestQuotaValue } from '@/utils/analytics/quota';
 import { dayOfMonthToWeekBucket, enumerateDatesInclusive, monthKeyToLabel } from '@/utils/dateKeys';
 import { isCodeReviewModel, isCodingAgentModel } from '@/utils/productClassification';
 import { calculateBilledOverageFromRows, calculateOverageRequests, calculateOverageCost } from '@/utils/userCalculations';
@@ -79,6 +79,8 @@ function buildNormalizedRowFromProcessedData(row: ProcessedData): NormalizedRow 
     product: row.product,
     sku: row.sku,
     unitType: row.unitType,
+    usageUnit: row.usageUnit,
+    billingQuantity: row.billingQuantity,
     organization: row.organization,
     costCenter: row.costCenter,
     appliedCostPerQuantity: row.appliedCostPerQuantity,
@@ -133,7 +135,7 @@ export function buildUsersExceedingQuota(usage: UsageArtifacts, quota: QuotaArti
   let count = 0;
   for (const u of usage.users) {
     const q = quota.quotaByUser.get(u.user);
-    if (q && q !== 'unknown' && u.totalRequests > q) count++;
+    if (isLegacyPremiumRequestQuotaValue(q) && u.totalRequests > q) count++;
   }
   return count;
 }
@@ -214,7 +216,10 @@ export function computeOverageSummaryFromArtifacts(usage: UsageArtifacts, quota:
   let totalOverageRequests = 0;
   for (const u of usage.users) {
     const q = quota.quotaByUser.get(u.user) ?? 'unknown';
-    totalOverageRequests += calculateOverageRequests(u.totalRequests, q);
+    totalOverageRequests += calculateOverageRequests(
+      u.totalRequests,
+      isLegacyPremiumRequestQuotaValue(q) ? q : 'unknown'
+    );
   }
   return { totalOverageRequests, totalOverageCost: calculateOverageCost(totalOverageRequests) };
 }
@@ -277,7 +282,7 @@ export function computeWeeklyQuotaExhaustionFromArtifacts(
       // Skip if already exhausted
       if (records.some(r => r.user === user)) continue;
       const quotaVal = quota.quotaByUser.get(user);
-      if (!quotaVal || quotaVal === 'unknown') continue;
+      if (!isLegacyPremiumRequestQuotaValue(quotaVal)) continue;
       const newTotal = (cumulative.get(user) || 0) + val;
       cumulative.set(user, newTotal);
       if (newTotal >= quotaVal) {

--- a/src/utils/ingestion/billingAccumulator.ts
+++ b/src/utils/ingestion/billingAccumulator.ts
@@ -1,7 +1,7 @@
 import type { ProcessedData } from '@/types/csv';
 import { shouldReplaceQuotaValue } from '@/utils/analytics/quota';
 import { calculateAicPoolEstimate, calculateIncludedAicCreditsForUsers } from '@/utils/aicPool';
-import { isRequestUnitType } from '@/utils/unitType';
+import { isSupportedUsageUnitType, type UsageUnitKind } from '@/utils/unitType';
 
 import {
   BillingArtifacts,
@@ -18,7 +18,10 @@ interface BillingAccumulatorRow {
   user: string;
   model: string;
   quantity: number;
+  billingQuantity?: number;
   unitType?: string;
+  usageUnit?: UsageUnitKind;
+  sku?: string;
   quotaValue?: number | 'unknown';
   organization?: string;
   costCenter?: string;
@@ -116,27 +119,31 @@ export class BillingAccumulator {
   private hasAnyAicData = false;
 
   addRow(row: BillingAccumulatorRow): void {
+    const billingRow = {
+      ...row,
+      quantity: row.billingQuantity ?? row.quantity,
+    };
     let entry: BillingUserTotals | SpecialBillingBucketTotals | undefined;
-    if (row.isNonCopilotUsage && row.usageBucket) {
-      entry = this.specialBucketMap.get(row.usageBucket);
+    if (billingRow.isNonCopilotUsage && billingRow.usageBucket) {
+      entry = this.specialBucketMap.get(billingRow.usageBucket);
       if (!entry) {
         entry = {
-          key: row.usageBucket,
+          key: billingRow.usageBucket,
           label: NON_COPILOT_CODE_REVIEW_LABEL,
           quantity: 0,
           quotaValue: 0,
         };
-        this.specialBucketMap.set(row.usageBucket, entry);
+        this.specialBucketMap.set(billingRow.usageBucket, entry);
       }
     } else {
-      entry = this.userMap.get(row.user);
+      entry = this.userMap.get(billingRow.user);
       if (!entry) {
-        entry = { user: row.user, quantity: 0 };
-        this.userMap.set(row.user, entry);
+        entry = { user: billingRow.user, quantity: 0 };
+        this.userMap.set(billingRow.user, entry);
       }
-      const incomingQuota = row.quotaValue;
+      const incomingQuota = billingRow.quotaValue;
       if (
-        isRequestUnitType(row.unitType)
+        isSupportedUsageUnitType(billingRow.unitType, billingRow.sku)
         && incomingQuota !== undefined
         && shouldReplaceQuotaValue(entry.quotaValue, incomingQuota)
       ) {
@@ -144,14 +151,14 @@ export class BillingAccumulator {
       }
     }
 
-    entry.quantity += row.quantity;
-    addOptionalBillingFields(entry, row);
+    entry.quantity += billingRow.quantity;
+    addOptionalBillingFields(entry, billingRow);
 
-    addGroupRow(this.orgTotals, row.organization || UNASSIGNED_BILLING_GROUP, row);
-    addGroupRow(this.costCenterTotals, row.costCenter || UNASSIGNED_BILLING_GROUP, row);
-    addGroupRow(this.billingByModel, row.model, row);
+    addGroupRow(this.orgTotals, billingRow.organization || UNASSIGNED_BILLING_GROUP, billingRow);
+    addGroupRow(this.costCenterTotals, billingRow.costCenter || UNASSIGNED_BILLING_GROUP, billingRow);
+    addGroupRow(this.billingByModel, billingRow.model, billingRow);
 
-    const signals = addBillingFields(this.totals, row);
+    const signals = addBillingFields(this.totals, billingRow);
     if (signals.sawBilling) this.hasAnyBillingData = true;
     if (signals.sawAicGross) this.hasAnyAicData = true;
   }
@@ -189,7 +196,8 @@ export function buildBillingArtifactsFromProcessedData(rows: ProcessedData[]): B
     accumulator.addRow({
       ...row,
       quantity: row.requestsUsed,
-      quotaValue: isRequestUnitType(row.unitType) ? row.quotaValue : undefined,
+      billingQuantity: row.billingQuantity,
+      quotaValue: isSupportedUsageUnitType(row.unitType, row.sku) ? row.quotaValue : undefined,
     });
   }
 

--- a/src/utils/ingestion/normalizeRow.ts
+++ b/src/utils/ingestion/normalizeRow.ts
@@ -6,7 +6,7 @@
 import { parseQuotaValue } from '@/utils/analytics/quota';
 import type { CSVData } from '@/types/csv';
 import { isCodeReviewModel } from '@/utils/productClassification';
-import { isRequestUnitType } from '@/utils/unitType';
+import { getUsageUnitKind } from '@/utils/unitType';
 
 import { normalizeDateToIso, type DateNormalizer } from './dateNormalization';
 import {
@@ -73,21 +73,26 @@ export function normalizeRow(
     return null;
   }
   
-  const unitType = typeof unit_type === 'string' ? unit_type.trim() : undefined;
-  const shouldUseRequestValues = isRequestUnitType(unitType);
+  const unitType = typeof unit_type === 'string' && unit_type.trim() !== '' ? unit_type.trim() : undefined;
+  const skuValue = typeof sku === 'string' ? sku : undefined;
+  const usageUnit = getUsageUnitKind(unitType, skuValue);
+  const shouldUseRequestValues = usageUnit === 'request';
+  const shouldUseAiCreditValues = usageUnit === 'ai_credit';
+  const shouldUseUsageValues = usageUnit !== 'unknown';
 
   // Parse quantity
   const parsedQty = typeof quantity === 'number' ? quantity : parseFloat(String(quantity));
-  if (shouldUseRequestValues && Number.isNaN(parsedQty) && !options.allowInvalidQuantity) {
+  if (shouldUseUsageValues && Number.isNaN(parsedQty) && !options.allowInvalidQuantity) {
     warnings.push(`Invalid quantity for user=${username} date=${date}`);
     return null;
   }
   const qty = shouldUseRequestValues ? parsedQty : 0;
+  const billingQty = shouldUseUsageValues ? parsedQty : 0;
   
   // Parse quota if present
   const quotaValue = isNonCopilotCodeReviewUsage
     ? 0
-    : shouldUseRequestValues && total_monthly_quota && typeof total_monthly_quota === 'string'
+    : shouldUseUsageValues && total_monthly_quota && typeof total_monthly_quota === 'string'
       ? parseQuotaValue(total_monthly_quota)
       : undefined;
   
@@ -103,11 +108,12 @@ export function normalizeRow(
     return Number.isNaN(n) ? undefined : n;
   };
   const parseRequestBillingAmount = (fieldName: string, v: unknown): number | undefined => {
-    if (shouldUseRequestValues) {
+    if (shouldUseUsageValues) {
       return parseNum(v);
     }
     return Object.prototype.hasOwnProperty.call(rawRecord, fieldName) ? 0 : undefined;
   };
+  const grossAmountValue = parseRequestBillingAmount('gross_amount', gross_amount);
 
   return {
     date: isoDate,
@@ -115,24 +121,26 @@ export function normalizeRow(
     user: trimmedUsername,
     model,
     quantity: qty,
+    billingQuantity: billingQty,
     quotaRaw: isNonCopilotCodeReviewUsage
       ? '0'
-      : shouldUseRequestValues && typeof total_monthly_quota === 'string'
+      : shouldUseUsageValues && typeof total_monthly_quota === 'string'
         ? total_monthly_quota
         : undefined,
     quotaValue,
     exceedsQuota,
     product: typeof product === 'string' ? product : undefined,
-    sku: typeof sku === 'string' ? sku : undefined,
+    sku: skuValue,
     unitType,
+    usageUnit,
     organization: typeof organization === 'string' ? organization : undefined,
     costCenter: typeof cost_center_name === 'string' ? cost_center_name : undefined,
     appliedCostPerQuantity: parseNum(applied_cost_per_quantity),
-    grossAmount: parseRequestBillingAmount('gross_amount', gross_amount),
+    grossAmount: grossAmountValue,
     discountAmount: parseRequestBillingAmount('discount_amount', discount_amount),
     netAmount: parseRequestBillingAmount('net_amount', net_amount),
-    aicQuantity: parseNum(aic_quantity),
-    aicGrossAmount: parseNum(aic_gross_amount),
+    aicQuantity: shouldUseAiCreditValues ? billingQty : parseNum(aic_quantity),
+    aicGrossAmount: shouldUseAiCreditValues ? grossAmountValue : parseNum(aic_gross_amount),
     isNonCopilotUsage: isNonCopilotCodeReviewUsage,
     usageBucket: isNonCopilotCodeReviewUsage ? NON_COPILOT_CODE_REVIEW_BUCKET : undefined,
   };

--- a/src/utils/ingestion/types.ts
+++ b/src/utils/ingestion/types.ts
@@ -3,6 +3,7 @@
  */
 
 import { PRICING } from '@/constants/pricing';
+import type { UsageUnitKind } from '@/utils/unitType';
 
 export const NON_COPILOT_CODE_REVIEW_BUCKET = 'non_copilot_code_review' as const;
 export const NON_COPILOT_CODE_REVIEW_LABEL = 'Non-Copilot Users' as const;
@@ -48,6 +49,8 @@ export interface NormalizedRow {
   product?: string;
   sku?: string;
   unitType?: string;
+  usageUnit?: UsageUnitKind;
+  billingQuantity?: number;
   organization?: string;
   costCenter?: string; // normalized from cost_center_name
   appliedCostPerQuantity?: number;

--- a/src/utils/productCosts.ts
+++ b/src/utils/productCosts.ts
@@ -42,7 +42,7 @@ export function createEmptyProductCostMap(): Map<ProductCategory, ProductCost> {
 
 export function accumulateProductCost(
   buckets: Map<ProductCategory, ProductCost>,
-  row: Pick<ProcessedData, 'model' | 'product' | 'sku' | 'requestsUsed' | 'grossAmount' | 'discountAmount' | 'netAmount' | 'aicQuantity' | 'aicGrossAmount' | 'isNonCopilotUsage' | 'usageBucket'>
+  row: Pick<ProcessedData, 'model' | 'product' | 'sku' | 'requestsUsed' | 'billingQuantity' | 'grossAmount' | 'discountAmount' | 'netAmount' | 'aicQuantity' | 'aicGrossAmount' | 'isNonCopilotUsage' | 'usageBucket'>
 ): void {
   const category = classifyProductCategory(row.model, row.product, row.sku, {
     isNonCopilotUsage: row.isNonCopilotUsage,
@@ -54,7 +54,7 @@ export function accumulateProductCost(
     return;
   }
 
-  bucket.requests += row.requestsUsed;
+  bucket.requests += row.billingQuantity ?? row.requestsUsed;
   bucket.gross += row.grossAmount ?? 0;
   bucket.discount += row.discountAmount ?? 0;
   bucket.net += row.netAmount ?? 0;

--- a/src/utils/unitType.ts
+++ b/src/utils/unitType.ts
@@ -1,3 +1,35 @@
+export type UsageUnitKind = 'request' | 'ai_credit' | 'unknown';
+
+function normalizeUsageValue(value: string | undefined): string {
+  return value?.trim().toLowerCase() ?? '';
+}
+
 export function isRequestUnitType(unitType: string | undefined): boolean {
-  return unitType === undefined || unitType.toLowerCase() === 'requests';
+  const normalizedUnitType = normalizeUsageValue(unitType);
+  return normalizedUnitType === '' || normalizedUnitType === 'requests';
+}
+
+export function isAiCreditUnitType(unitType: string | undefined): boolean {
+  const normalizedUnitType = normalizeUsageValue(unitType);
+  return normalizedUnitType === 'ai-credit' || normalizedUnitType === 'ai-credits';
+}
+
+export function isAiCreditSku(sku: string | undefined): boolean {
+  return normalizeUsageValue(sku) === 'copilot_ai_credit';
+}
+
+export function getUsageUnitKind(unitType: string | undefined, sku?: string): UsageUnitKind {
+  if (isAiCreditUnitType(unitType) || isAiCreditSku(sku)) {
+    return 'ai_credit';
+  }
+
+  if (isRequestUnitType(unitType)) {
+    return 'request';
+  }
+
+  return 'unknown';
+}
+
+export function isSupportedUsageUnitType(unitType: string | undefined, sku?: string): boolean {
+  return getUsageUnitKind(unitType, sku) !== 'unknown';
 }


### PR DESCRIPTION
GitHub Copilot billing exports now include usage-based AI Credits rows rather than PRU request rows. This PR teaches the parser and analytics pipeline to treat current AI Credit billing quantities as billing usage without polluting request analytics, and updates reporting surfaces to use usage-based terminology.

## Summary

- Adds AI Credit SKU/unit detection, 1900/3900 quota tiers, and canonical `billingQuantity` handling for current reports.
- Keeps AI Credit quantities separate from PRU/request analytics so overage, savings, and request charts stay request-based for legacy exports.
- Updates billing summaries, product/model/user/detail/organization/cost-center tables, and model charts with usage-based labels like AI Credits, Included Credits, Additional usage, and Gross Amount.
- Suppresses duplicate AI Credits Gross columns for current usage-based reports while retaining legacy AIC preview behavior.
- Adds regression coverage for parsing, quota classification, aggregation, labels, and chart/table behavior.

## Commit summary

| Commit | Change |
|--------|--------|
| `feat: parse usage-based billing rows` | Adds current AI Credit SKU/unit detection, quota tiers, `billingQuantity`, and aggregation rules while preserving PRU request analytics. |
| `feat: update usage-based billing tables` | Updates overview, users, detail, organization, and cost-center billing tables with usage-based labels and duplicate-column suppression. |
| `feat: chart daily model AI credits` | Switches model trend charts to daily AI Credit quantities for usage-based reports while preserving request charts for legacy reports. |
| `test: cover usage-based billing reports` | Adds parser, quota, aggregation, label, table, and chart regressions for both current and legacy billing formats. |

## Validation

- `npm run build && npm run lint && npm run test` (passes with the existing `AdvisorySection` exhaustive-deps warning)