### PR TITLE
Remove usage-based billing preview banner

### DIFF
--- a/__tests__/components/DataAnalysisBilling.test.tsx
+++ b/__tests__/components/DataAnalysisBilling.test.tsx
@@ -171,10 +171,10 @@ describe('DataAnalysis billing summary', () => {
     render(<DataAnalysis ingestionResult={ingestionResult} filename="billing-export.csv" onReset={() => {}} />);
 
     await waitFor(() => {
-      expect(screen.getByText('Usage-based billing preview')).toBeInTheDocument();
-      expect(screen.getByText(/Learn more about usage-based billing/)).toBeInTheDocument();
-      expect(screen.getByRole('link', { name: 'gh.io/copilot-billing-blog' })).toHaveAttribute('href', 'https://gh.io/copilot-billing-blog');
-      expect(screen.getByRole('link', { name: 'gh.io/billing-preview' })).toHaveAttribute('href', 'https://gh.io/billing-preview');
+      expect(screen.queryByText('Usage-based billing preview')).not.toBeInTheDocument();
+      expect(screen.queryByText(/Learn more about usage-based billing/)).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'gh.io/copilot-billing-blog' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'gh.io/billing-preview' })).not.toBeInTheDocument();
       expect(screen.getAllByText('AI Credits').length).toBeGreaterThan(0);
       expect(screen.getByLabelText('ai-credits-summary')).toHaveTextContent('$0.39');
       expect(screen.getByLabelText('ai-credits-summary')).toHaveTextContent('AI Credits included');
@@ -345,7 +345,7 @@ describe('DataAnalysis billing summary', () => {
     render(<DataAnalysis ingestionResult={ingestionResult} filename="billing-export.csv" onReset={() => {}} />);
 
     await waitFor(() => {
-      expect(screen.getByText('Usage-based billing preview')).toBeInTheDocument();
+      expect(screen.queryByText('Usage-based billing preview')).not.toBeInTheDocument();
       expect(screen.getByLabelText('ai-credits-summary')).toHaveTextContent('$0.00');
       expect(screen.getAllByRole('columnheader', { name: 'AI Credits Gross' })).toHaveLength(2);
     });

--- a/src/components/DataAnalysis.tsx
+++ b/src/components/DataAnalysis.tsx
@@ -410,37 +410,6 @@ function DataAnalysisInner() {
           ) : (
             /* Overview — chart + model table */
             <div className="space-y-6">
-              {aicMetricsAvailable && aggregatedAic && (
-                <div className="bg-[#eef2ff] border border-[#c7d2fe] rounded-md p-4 opacity-0 animate-fade-in-up" style={{ animationDelay: '25ms' }}>
-                  <h3 className="text-sm font-semibold text-[#1f2328]">Usage-based billing preview</h3>
-                  <p className="text-sm text-[#6366f1] mt-1">
-                    GitHub Copilot is transitioning to usage-based billing with AI Credits based on token consumption.
-                  </p>
-                  <p className="text-sm text-[#6366f1] mt-2">
-                    Learn more about usage-based billing &rarr;{' '}
-                    <a
-                      href="https://gh.io/copilot-billing-blog"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="font-semibold text-[#0969da] hover:underline"
-                    >
-                      gh.io/copilot-billing-blog
-                    </a>
-                  </p>
-                  <p className="text-sm text-[#6366f1] mt-1">
-                    Use the billing preview app to understand the new bill format &rarr;{' '}
-                    <a
-                      href="https://gh.io/billing-preview"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="font-semibold text-[#0969da] hover:underline"
-                    >
-                      gh.io/billing-preview
-                    </a>
-                  </p>
-                </div>
-              )}
-
               {/* Current Billing + Licenses row */}
               {costMetricsAvailable && aggregatedCosts && (
                 <div className={`grid grid-cols-1 ${aggregatedAic ? 'md:grid-cols-3' : 'md:grid-cols-2'} gap-6 opacity-0 animate-fade-in-up`} style={{ animationDelay: '50ms' }}>


### PR DESCRIPTION
The usage-based billing preview callout is no longer needed in the overview, but the AI Credits summary and billing tables should continue to render when AI credit data is present.

## Summary

Removes the preview info banner and updates billing coverage to assert the banner and its links stay hidden while the AI Credits UI remains visible.

| Commit | Change |
|--------|--------|
| `fix:` remove billing preview banner | Removed the obsolete overview callout and updated billing tests to cover the new expected UI state. |

## Validation

- `npm run build`
- `npm run lint`
- `npm run test -- --runInBand`