### PR TITLE
Hide quota pages for usage-based billing reports

### DIFF
--- a/__tests__/components/DataAnalysisBilling.test.tsx
+++ b/__tests__/components/DataAnalysisBilling.test.tsx
@@ -433,6 +433,8 @@ describe('DataAnalysis billing summary', () => {
       expect(screen.getByText('Total: 42.50 AI Credits')).toBeInTheDocument();
       expect(screen.getAllByRole('columnheader', { name: 'Included Credits' }).length).toBeGreaterThanOrEqual(2);
       expect(screen.getAllByRole('columnheader', { name: 'Additional usage' }).length).toBeGreaterThanOrEqual(2);
+      expect(screen.queryByRole('button', { name: 'Insights' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Cost Optimization' })).not.toBeInTheDocument();
     });
 
     const modelDetailsHeading = screen.getByRole('heading', { name: 'Model Details' });

--- a/__tests__/components/DataAnalysisBilling.test.tsx
+++ b/__tests__/components/DataAnalysisBilling.test.tsx
@@ -433,8 +433,8 @@ describe('DataAnalysis billing summary', () => {
       expect(screen.getByText('Total: 42.50 AI Credits')).toBeInTheDocument();
       expect(screen.getAllByRole('columnheader', { name: 'Included Credits' }).length).toBeGreaterThanOrEqual(2);
       expect(screen.getAllByRole('columnheader', { name: 'Additional usage' }).length).toBeGreaterThanOrEqual(2);
-      expect(screen.queryByRole('button', { name: 'Insights' })).not.toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Cost Optimization' })).not.toBeInTheDocument();
+      expect(screen.queryAllByRole('button', { name: 'Insights' })).toHaveLength(0);
+      expect(screen.queryAllByRole('button', { name: 'Cost Optimization' })).toHaveLength(0);
     });
 
     const modelDetailsHeading = screen.getByRole('heading', { name: 'Model Details' });
@@ -477,6 +477,49 @@ describe('DataAnalysis billing summary', () => {
       expect(screen.getByRole('columnheader', { name: 'Additional usage' })).toBeInTheDocument();
       expect(screen.queryByRole('columnheader', { name: 'AI Credits Gross' })).not.toBeInTheDocument();
       expect(screen.queryByRole('columnheader', { name: 'Gross' })).not.toBeInTheDocument();
+    });
+  });
+
+  it.each([
+    { buttonName: 'Insights', headingName: 'Consumption Insights' },
+    { buttonName: 'Cost Optimization', headingName: 'Cost Optimization' },
+  ])('redirects from $buttonName when rerendered with a usage-based report', async ({ buttonName, headingName }) => {
+    const usageBasedRows: CSVData[] = [
+      {
+        date: '2026-06-01',
+        username: 'test-user-one',
+        product: 'copilot',
+        sku: 'copilot_ai_credit',
+        model: 'Auto: Claude Haiku 4.5',
+        quantity: '42.5',
+        unit_type: 'ai-credits',
+        applied_cost_per_quantity: '0.01',
+        gross_amount: '0.425',
+        discount_amount: '0.425',
+        net_amount: '0',
+        total_monthly_quota: '3900',
+        organization: 'test-org-one',
+        cost_center_name: 'test-cost-center-one',
+      },
+    ];
+    const requestReport = createIngestionResultFromRawRows(newFormatRows);
+    const usageBasedReport = createIngestionResultFromRawRows(usageBasedRows);
+    const { rerender } = render(
+      <DataAnalysis ingestionResult={requestReport} filename="request-report.csv" onReset={() => {}} />
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: buttonName })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: headingName })).toBeInTheDocument();
+    });
+
+    rerender(<DataAnalysis ingestionResult={usageBasedReport} filename="usage-based.csv" onReset={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'AI Credits by Model' })).toBeInTheDocument();
+      expect(screen.queryAllByRole('button', { name: 'Insights' })).toHaveLength(0);
+      expect(screen.queryAllByRole('button', { name: 'Cost Optimization' })).toHaveLength(0);
     });
   });
 

--- a/src/components/DataAnalysis.tsx
+++ b/src/components/DataAnalysis.tsx
@@ -119,6 +119,11 @@ const AI_USAGE_NAV_ITEM: NavigationItem = {
   ),
 };
 
+const USAGE_BASED_BILLING_HIDDEN_VIEWS = new Set<NavigationItem['key']>([
+  'insights',
+  'costOptimization',
+]);
+
 function DataAnalysisInner() {
   const {
     view,
@@ -184,7 +189,9 @@ function DataAnalysisInner() {
   }, [analysis.quotaBreakdown.mixed, planInfo, quotaArtifacts.distinctQuotas, selectedPlan]);
 
   const navItems = useMemo(() => {
-    const items = [...NAV_ITEMS];
+    const items = isUsageBasedBilling
+      ? NAV_ITEMS.filter((item) => !USAGE_BASED_BILLING_HIDDEN_VIEWS.has(item.key))
+      : [...NAV_ITEMS];
     let insertIdx = 2; // After 'users'
     if (hasCostCenters) {
       items.splice(insertIdx, 0, COST_CENTERS_NAV_ITEM);
@@ -197,7 +204,7 @@ function DataAnalysisInner() {
       items.push(AI_USAGE_NAV_ITEM);
     }
     return items;
-  }, [aicMetricsAvailable, hasCostCenters, hasOrganizations]);
+  }, [aicMetricsAvailable, hasCostCenters, hasOrganizations, isUsageBasedBilling]);
 
   useEffect(() => {
     if (!hasCostCenters && view === 'costCenters') {
@@ -209,7 +216,10 @@ function DataAnalysisInner() {
     if (!aicMetricsAvailable && view === 'aiUsage') {
       setView('overview');
     }
-  }, [aicMetricsAvailable, hasCostCenters, hasOrganizations, setView, view]);
+    if (isUsageBasedBilling && USAGE_BASED_BILLING_HIDDEN_VIEWS.has(view)) {
+      setView('overview');
+    }
+  }, [aicMetricsAvailable, hasCostCenters, hasOrganizations, isUsageBasedBilling, setView, view]);
 
   const costMetricsAvailable = billingArtifacts?.hasAnyBillingData === true;
   const aggregatedCosts = costMetricsAvailable && billingArtifacts ? billingArtifacts.totals : null;


### PR DESCRIPTION
Usage-based billing reports are AI Credits-only and do not support the quota-oriented Consumption insights and Cost Optimization pages. This PR hides those navigation entries for usage-based uploads and redirects any active hidden view back to Overview.

## Summary

| Commit | Change |
|--------|--------|
| `fix: hide quota pages for usage-based reports` | Filters Insights and Cost Optimization from the dashboard navigation for usage-based billing reports and covers the behavior in the billing component tests. |
| `test: cover usage-based navigation redirect` | Addresses review feedback by using robust absence assertions and adding rerender coverage that proves active hidden views return to Overview for usage-based reports. |

## Validation

- `npm run build && npm run lint && npm run test`