### PR TITLE
Add AI Credits agent usage and Auto Mode savings

### DIFF
--- a/__tests__/components/CodingAgentOverview.test.tsx
+++ b/__tests__/components/CodingAgentOverview.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, within } from '@testing-library/react';
 
 import { AnalysisContext } from '@/context/AnalysisContext';
 import { CodingAgentOverview } from '@/components/CodingAgentOverview';
+import { PRICING } from '@/constants/pricing';
 import type { CodeReviewAnalysis, CodingAgentUser, ProcessedData } from '@/types/csv';
 import type {
   BillingArtifacts,
@@ -11,9 +12,31 @@ import type {
   UsageArtifacts,
 } from '@/utils/ingestion';
 
+function buildProcessedRow(partial: Partial<ProcessedData>): ProcessedData {
+  const timestamp = new Date('2026-03-01T00:00:00Z');
+
+  return {
+    timestamp,
+    user: 'test-user-one',
+    model: 'Coding Agent model',
+    requestsUsed: 0,
+    exceedsQuota: false,
+    totalQuota: String(PRICING.ENTERPRISE_AI_CREDIT_QUOTA),
+    quotaValue: PRICING.ENTERPRISE_AI_CREDIT_QUOTA,
+    iso: timestamp.toISOString(),
+    dateKey: '2026-03-01',
+    monthKey: '2026-03',
+    epoch: timestamp.getTime(),
+    usageUnit: 'ai_credit',
+    billingQuantity: 0,
+    ...partial,
+  };
+}
+
 jest.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div data-testid="chart-container">{children}</div>,
   BarChart: ({ children }: { children: React.ReactNode }) => <div data-testid="bar-chart">{children}</div>,
+  LineChart: ({ children }: { children: React.ReactNode }) => <div data-testid="line-chart">{children}</div>,
   Bar: () => <div data-testid="bar" />,
   Line: () => <div data-testid="line" />,
   XAxis: () => <div data-testid="x-axis" />,
@@ -62,6 +85,7 @@ function createContextValue() {
     userData: [],
     allModels: [],
     dailyCumulativeData: [],
+    dailyAicCumulativeData: [],
     codingAgentAnalysis: { totalUsers: 0, totalUniqueUsers: 0, totalCodingAgentRequests: 0, adoptionRate: 0, users: [] },
     codeReviewAnalysis: { totalUsers: 0, totalUniqueUsers: 0, totalCodeReviewRequests: 0, adoptionRate: 0, users: [] },
     weeklyExhaustion: { totalUsersExhausted: 0, weeks: [] },
@@ -142,5 +166,127 @@ describe('CodingAgentOverview', () => {
     expect(syntheticRow).not.toBeNull();
     expect(within(syntheticRow as HTMLElement).getByText('4.0')).toBeInTheDocument();
     expect(within(syntheticRow as HTMLElement).getByText('0')).toBeInTheDocument();
+  });
+
+  it('renders usage-based agent tables in AI Credits with billing columns', () => {
+    const aggregateProcessedData: ProcessedData[] = [
+      buildProcessedRow({
+        user: 'test-user-one',
+        model: 'Coding Agent model',
+        billingQuantity: 12.34,
+        aicQuantity: 12.34,
+        grossAmount: 0.1234,
+        discountAmount: 0.1,
+        netAmount: 0.0234,
+      }),
+      buildProcessedRow({
+        user: 'test-user-one',
+        model: 'Code Review model',
+        billingQuantity: 3.5,
+        aicQuantity: 3.5,
+        grossAmount: 0.035,
+        discountAmount: 0.01,
+        netAmount: 0.025,
+      }),
+      buildProcessedRow({
+        user: '',
+        model: 'Code Review model',
+        billingQuantity: 2,
+        aicQuantity: 2,
+        grossAmount: 0.02,
+        discountAmount: 0,
+        netAmount: 0.02,
+        quotaValue: 0,
+        isNonCopilotUsage: true,
+        usageBucket: 'non_copilot_code_review',
+      }),
+    ];
+
+    const dailyUserAicModelTotals = new Map<string, Map<string, Map<string, number>>>();
+    dailyUserAicModelTotals.set('2026-03-01', new Map([
+      ['test-user-one', new Map([
+        ['Coding Agent model', 12.34],
+        ['Code Review model', 3.5],
+      ])],
+    ]));
+
+    const codingAgentUsers: CodingAgentUser[] = [
+      {
+        user: 'test-user-one',
+        totalRequests: 0,
+        codingAgentRequests: 0,
+        codingAgentPercentage: 0,
+        quota: PRICING.ENTERPRISE_AI_CREDIT_QUOTA,
+        models: ['Coding Agent model'],
+      },
+    ];
+    const codeReviewAnalysis: CodeReviewAnalysis = {
+      totalUsers: 1,
+      totalUniqueUsers: 1,
+      totalCodeReviewRequests: 0,
+      adoptionRate: 100,
+      users: [
+        {
+          user: 'test-user-one',
+          totalRequests: 0,
+          codeReviewRequests: 0,
+          codeReviewPercentage: 0,
+          quota: PRICING.ENTERPRISE_AI_CREDIT_QUOTA,
+          models: ['Code Review model'],
+        },
+        {
+          user: 'Non-Copilot Users',
+          totalRequests: 0,
+          codeReviewRequests: 0,
+          codeReviewPercentage: 0,
+          quota: 0,
+          models: ['Code Review model'],
+          isSyntheticNonCopilotRow: true,
+        },
+      ],
+    };
+
+    render(
+      <AnalysisContext.Provider
+        value={{
+          ...createContextValue(),
+          aggregateProcessedData,
+          dailyBucketsArtifacts: {
+            dailyUserTotals: new Map(),
+            dailyUserAicModelTotals,
+            dateRange: { min: '2026-03-01', max: '2026-03-01' },
+          } as DailyBucketsArtifacts,
+        }}
+      >
+        <CodingAgentOverview
+          codingAgentUsers={codingAgentUsers}
+          totalUniqueUsers={1}
+          adoptionRate={100}
+          codeReviewAnalysis={codeReviewAnalysis}
+        />
+      </AnalysisContext.Provider>
+    );
+
+    expect(screen.getAllByText('Daily and cumulative AI Credits usage')).toHaveLength(2);
+    expect(screen.getAllByRole('columnheader', { name: 'AI Credits' })).toHaveLength(2);
+    expect(screen.getAllByRole('columnheader', { name: 'Gross Amount' })).toHaveLength(2);
+    expect(screen.getAllByRole('columnheader', { name: 'Included Credits' })).toHaveLength(2);
+    expect(screen.getAllByRole('columnheader', { name: 'Additional usage' })).toHaveLength(2);
+
+    const agentHeading = screen.getByRole('heading', { name: 'Agent Users' });
+    const agentTable = agentHeading.parentElement?.nextElementSibling?.querySelector('table') as HTMLTableElement;
+    const agentRow = within(agentTable).getByText('test-user-one').closest('tr');
+    expect(agentRow).not.toBeNull();
+    expect(within(agentRow as HTMLElement).getByText('12.34')).toBeInTheDocument();
+    expect(within(agentRow as HTMLElement).getByText('$0.12')).toBeInTheDocument();
+    expect(within(agentRow as HTMLElement).getByText('-$0.10')).toBeInTheDocument();
+    expect(within(agentRow as HTMLElement).getByText('$0.02')).toBeInTheDocument();
+
+    const reviewHeading = screen.getByRole('heading', { name: 'Code Review Users' });
+    const reviewTable = reviewHeading.parentElement?.nextElementSibling?.querySelector('table') as HTMLTableElement;
+    const syntheticRow = within(reviewTable).getByText('Non-Copilot Users').closest('tr');
+    expect(syntheticRow).not.toBeNull();
+    expect(within(syntheticRow as HTMLElement).getByText('2.00')).toBeInTheDocument();
+    expect(within(syntheticRow as HTMLElement).getAllByText('$0.02')).toHaveLength(2);
   });
 });

--- a/__tests__/components/DataAnalysisBilling.test.tsx
+++ b/__tests__/components/DataAnalysisBilling.test.tsx
@@ -431,6 +431,12 @@ describe('DataAnalysis billing summary', () => {
       expect(screen.getByRole('heading', { name: 'AI Credits by Model' })).toBeInTheDocument();
       expect(screen.queryByRole('heading', { name: 'Requests by Model' })).not.toBeInTheDocument();
       expect(screen.getByText('Total: 42.50 AI Credits')).toBeInTheDocument();
+      expect(screen.getByText('Auto Mode Savings')).toBeInTheDocument();
+      expect(screen.getByText(/10% AI Credits discount/)).toBeInTheDocument();
+      expect(screen.getAllByText('42.50').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('$0.47').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('$0.04').length).toBeGreaterThan(0);
+      expect(screen.getByText('$0.04 saved')).toBeInTheDocument();
       expect(screen.getAllByRole('columnheader', { name: 'Included Credits' }).length).toBeGreaterThanOrEqual(2);
       expect(screen.getAllByRole('columnheader', { name: 'Additional usage' }).length).toBeGreaterThanOrEqual(2);
       expect(screen.queryAllByRole('button', { name: 'Insights' })).toHaveLength(0);
@@ -631,7 +637,7 @@ describe('DataAnalysis billing summary', () => {
     await waitFor(() => {
       expect(screen.getByText('Auto Mode Savings')).toBeInTheDocument();
       expect(screen.getByText('GPT-5.3-Codex')).toBeInTheDocument();
-      expect(screen.getAllByText('1.00').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('0.90').length).toBeGreaterThan(0);
       expect(screen.getAllByText('$0.04').length).toBeGreaterThan(0);
       expect(screen.getAllByText('$0.00').length).toBeGreaterThan(0);
       expect(screen.getByText('$0.00 saved')).toBeInTheDocument();

--- a/__tests__/utils/artifactCodeReviewDailyUsage.test.ts
+++ b/__tests__/utils/artifactCodeReviewDailyUsage.test.ts
@@ -1,4 +1,9 @@
-import { buildDailyCodeReviewUsageFromArtifacts, DailyBucketsArtifacts, DailyCodingAgentUsageDatum } from '@/utils/ingestion';
+import {
+  buildDailyCodeReviewAicUsageFromArtifacts,
+  buildDailyCodeReviewUsageFromArtifacts,
+  DailyBucketsArtifacts,
+  DailyCodingAgentUsageDatum,
+} from '@/utils/ingestion';
 
 describe('buildDailyCodeReviewUsageFromArtifacts', () => {
   function makeArtifacts(): DailyBucketsArtifacts {
@@ -107,5 +112,25 @@ describe('buildDailyCodeReviewUsageFromArtifacts', () => {
       dateRange: { min: '2025-06-01', max: '2025-06-02' }
     };
     expect(buildDailyCodeReviewUsageFromArtifacts(artifacts)).toEqual([]);
+  });
+
+  test('aggregates AI Credits from the AI Credits per-model breakdown', () => {
+    const dailyUserAicModelTotals = new Map<string, Map<string, Map<string, number>>>();
+    const day = new Map<string, Map<string, number>>();
+    const userModels = new Map<string, number>();
+    userModels.set('Code Review model', 8.25);
+    userModels.set('Coding Agent model', 3);
+    day.set('test-user-one', userModels);
+    dailyUserAicModelTotals.set('2026-03-01', day);
+
+    const artifacts: DailyBucketsArtifacts = {
+      dailyUserTotals: new Map(),
+      dailyUserAicModelTotals,
+      dateRange: { min: '2026-03-01', max: '2026-03-01' }
+    };
+
+    expect(buildDailyCodeReviewAicUsageFromArtifacts(artifacts)).toEqual([
+      { date: '2026-03-01', dailyRequests: 8.25, cumulativeRequests: 8.25 }
+    ]);
   });
 });

--- a/__tests__/utils/artifactCodingAgentDailyUsage.test.ts
+++ b/__tests__/utils/artifactCodingAgentDailyUsage.test.ts
@@ -1,4 +1,9 @@
-import { buildDailyCodingAgentUsageFromArtifacts, DailyBucketsArtifacts, DailyCodingAgentUsageDatum } from '@/utils/ingestion';
+import {
+  buildDailyCodingAgentAicUsageFromArtifacts,
+  buildDailyCodingAgentUsageFromArtifacts,
+  DailyBucketsArtifacts,
+  DailyCodingAgentUsageDatum,
+} from '@/utils/ingestion';
 
 describe('buildDailyCodingAgentUsageFromArtifacts', () => {
   function makeArtifacts(): DailyBucketsArtifacts {
@@ -57,5 +62,25 @@ describe('buildDailyCodingAgentUsageFromArtifacts', () => {
       dateRange: { min: '2025-06-01', max: '2025-06-02' }
     };
     expect(buildDailyCodingAgentUsageFromArtifacts(artifacts)).toEqual([]);
+  });
+
+  test('aggregates AI Credits from the AI Credits per-model breakdown', () => {
+    const dailyUserAicModelTotals = new Map<string, Map<string, Map<string, number>>>();
+    const day = new Map<string, Map<string, number>>();
+    const userModels = new Map<string, number>();
+    userModels.set('Coding Agent model', 12.5);
+    userModels.set('Code Review model', 4);
+    day.set('test-user-one', userModels);
+    dailyUserAicModelTotals.set('2026-03-01', day);
+
+    const artifacts: DailyBucketsArtifacts = {
+      dailyUserTotals: new Map(),
+      dailyUserAicModelTotals,
+      dateRange: { min: '2026-03-01', max: '2026-03-01' }
+    };
+
+    expect(buildDailyCodingAgentAicUsageFromArtifacts(artifacts)).toEqual([
+      { date: '2026-03-01', dailyRequests: 12.5, cumulativeRequests: 12.5 }
+    ]);
   });
 });

--- a/__tests__/utils/autoModeSavings.test.ts
+++ b/__tests__/utils/autoModeSavings.test.ts
@@ -41,7 +41,7 @@ describe('Auto Mode savings', () => {
     const [result] = aggregateAutoModeSavings(rows);
 
     expect(result.model).toBe('GPT-5.3-Codex');
-    expect(result.requests).toBeCloseTo(2.7);
+    expect(result.quantity).toBeCloseTo(2.7);
     expect(result.costBeforeAuto).toBeCloseTo(0.1188);
     expect(result.savings).toBeCloseTo(0.0108);
   });
@@ -59,7 +59,7 @@ describe('Auto Mode savings', () => {
     const [result] = aggregateAutoModeSavings(rows);
 
     expect(result.model).toBe('GPT-5.3-Codex');
-    expect(result.requests).toBeCloseTo(0.9);
+    expect(result.quantity).toBeCloseTo(0.9);
     expect(result.costBeforeAuto).toBeCloseTo(0.0396);
     expect(result.savings).toBeCloseTo(0.0036);
   });
@@ -75,7 +75,7 @@ describe('Auto Mode savings', () => {
 
     const [result] = aggregateAutoModeSavings(rows);
 
-    expect(result.requests).toBeCloseTo(553.5);
+    expect(result.quantity).toBeCloseTo(553.5);
     expect(result.costBeforeAuto).toBeCloseTo(24.354);
     expect(result.savings).toBeCloseTo(2.214);
   });
@@ -97,9 +97,29 @@ describe('Auto Mode savings', () => {
     const [result] = aggregateAutoModeSavings(rows);
 
     expect(result.model).toBe('GPT-5.3-Codex');
-    expect(result.requests).toBeCloseTo(100);
+    expect(result.quantity).toBeCloseTo(100);
     expect(result.costBeforeAuto).toBeCloseTo(1.1);
     expect(result.savings).toBeCloseTo(0.1);
+  });
+
+  it('uses row-specific AI Credit unit cost when gross amount is absent', () => {
+    const rows: ProcessedData[] = [
+      createRow({
+        requestsUsed: 0,
+        usageUnit: 'ai_credit',
+        billingQuantity: 100,
+        aicQuantity: 100,
+        appliedCostPerQuantity: 0.02,
+        grossAmount: undefined,
+        netAmount: undefined,
+      }),
+    ];
+
+    const [result] = aggregateAutoModeSavings(rows);
+
+    expect(result.quantity).toBeCloseTo(100);
+    expect(result.costBeforeAuto).toBeCloseTo(2.2);
+    expect(result.savings).toBeCloseTo(0.2);
   });
 
   it('keeps consumed AI Credits separate from the 10% higher before-Auto cost', () => {
@@ -115,7 +135,7 @@ describe('Auto Mode savings', () => {
 
     const [result] = aggregateAutoModeSavings(rows);
 
-    expect(result.requests).toBeCloseTo(21404.23);
+    expect(result.quantity).toBeCloseTo(21404.23);
     expect(result.costBeforeAuto).toBeCloseTo(235.444);
     expect(result.savings).toBeCloseTo(21.404);
   });

--- a/__tests__/utils/autoModeSavings.test.ts
+++ b/__tests__/utils/autoModeSavings.test.ts
@@ -41,9 +41,9 @@ describe('Auto Mode savings', () => {
     const [result] = aggregateAutoModeSavings(rows);
 
     expect(result.model).toBe('GPT-5.3-Codex');
-    expect(result.requests).toBeCloseTo(3);
-    expect(result.costBeforeAuto).toBeCloseTo(0.12);
-    expect(result.savings).toBeCloseTo(0.012);
+    expect(result.requests).toBeCloseTo(2.7);
+    expect(result.costBeforeAuto).toBeCloseTo(0.1188);
+    expect(result.savings).toBeCloseTo(0.0108);
   });
 
   it('falls back to standard pricing when billing cost fields are absent', () => {
@@ -59,9 +59,9 @@ describe('Auto Mode savings', () => {
     const [result] = aggregateAutoModeSavings(rows);
 
     expect(result.model).toBe('GPT-5.3-Codex');
-    expect(result.requests).toBeCloseTo(1);
-    expect(result.costBeforeAuto).toBeCloseTo(0.04);
-    expect(result.savings).toBeCloseTo(0.004);
+    expect(result.requests).toBeCloseTo(0.9);
+    expect(result.costBeforeAuto).toBeCloseTo(0.0396);
+    expect(result.savings).toBeCloseTo(0.0036);
   });
 
   it('does not treat unrelated billing discounts as Auto Mode savings', () => {
@@ -75,8 +75,48 @@ describe('Auto Mode savings', () => {
 
     const [result] = aggregateAutoModeSavings(rows);
 
-    expect(result.requests).toBeCloseTo(615);
-    expect(result.costBeforeAuto).toBeCloseTo(24.6);
-    expect(result.savings).toBeCloseTo(2.46);
+    expect(result.requests).toBeCloseTo(553.5);
+    expect(result.costBeforeAuto).toBeCloseTo(24.354);
+    expect(result.savings).toBeCloseTo(2.214);
+  });
+
+  it('aggregates usage-based Auto rows in AI Credits', () => {
+    const rows: ProcessedData[] = [
+      createRow({
+        requestsUsed: 0,
+        usageUnit: 'ai_credit',
+        billingQuantity: 100,
+        aicQuantity: 100,
+        appliedCostPerQuantity: 0.01,
+        grossAmount: 1,
+        discountAmount: 1,
+        netAmount: 0,
+      }),
+    ];
+
+    const [result] = aggregateAutoModeSavings(rows);
+
+    expect(result.model).toBe('GPT-5.3-Codex');
+    expect(result.requests).toBeCloseTo(100);
+    expect(result.costBeforeAuto).toBeCloseTo(1.1);
+    expect(result.savings).toBeCloseTo(0.1);
+  });
+
+  it('keeps consumed AI Credits separate from the 10% higher before-Auto cost', () => {
+    const rows: ProcessedData[] = [
+      createRow({
+        requestsUsed: 0,
+        usageUnit: 'ai_credit',
+        billingQuantity: 21404.23,
+        aicQuantity: 21404.23,
+        grossAmount: 214.04,
+      }),
+    ];
+
+    const [result] = aggregateAutoModeSavings(rows);
+
+    expect(result.requests).toBeCloseTo(21404.23);
+    expect(result.costBeforeAuto).toBeCloseTo(235.444);
+    expect(result.savings).toBeCloseTo(21.404);
   });
 });

--- a/src/components/CodingAgentOverview.tsx
+++ b/src/components/CodingAgentOverview.tsx
@@ -1,18 +1,105 @@
 'use client';
 
 import React, { useState, useMemo } from 'react';
-import { CodingAgentUsageChart } from './charts/CodingAgentUsageChart';
-import { useIsMobile } from '@/hooks/useIsMobile';
+
 import { useAnalysisContext } from '@/context/AnalysisContext';
-import { DailyBucketsArtifacts, buildDailyCodingAgentUsageFromArtifacts, buildDailyCodeReviewUsageFromArtifacts } from '@/utils/ingestion';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import type { CodeReviewAnalysis, CodingAgentUser, ProcessedData } from '@/types/csv';
+import { getBillingCostLabels } from '@/utils/billingLabels';
+import { formatCurrency } from '@/utils/formatters';
+import {
+  buildDailyCodeReviewAicUsageFromArtifacts,
+  buildDailyCodeReviewUsageFromArtifacts,
+  buildDailyCodingAgentAicUsageFromArtifacts,
+  buildDailyCodingAgentUsageFromArtifacts,
+  DailyBucketsArtifacts,
+  NON_COPILOT_CODE_REVIEW_LABEL,
+} from '@/utils/ingestion';
 import { filterDailySeriesByMonths } from '@/utils/analytics/filters';
-import type { CodeReviewAnalysis } from '@/types/csv';
+import { isCodeReviewModel, isCodingAgentModel } from '@/utils/productClassification';
+
+import { CodingAgentUsageChart } from './charts/CodingAgentUsageChart';
 
 interface CodingAgentOverviewProps {
-  codingAgentUsers: import('@/types/csv').CodingAgentUser[];
+  codingAgentUsers: CodingAgentUser[];
   totalUniqueUsers: number;
   adoptionRate: number;
   codeReviewAnalysis: CodeReviewAnalysis;
+}
+
+interface AgentUsageTableRow {
+  user: string;
+  quantity: number;
+  gross: number;
+  included: number;
+  additional: number;
+  quota: number | 'unknown';
+  isSyntheticNonCopilotRow?: boolean;
+}
+
+function formatUsageQuantity(value: number, isUsageBasedBilling: boolean): string {
+  if (isUsageBasedBilling) {
+    return value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  }
+
+  return value.toFixed(1);
+}
+
+function formatQuotaValue(quota: number | 'unknown'): string {
+  return quota === 'unknown' ? 'Unknown' : quota.toLocaleString();
+}
+
+function buildUsageBasedAgentRows(
+  rows: ProcessedData[],
+  modelFilter: (model: string) => boolean
+): AgentUsageTableRow[] {
+  const rowsByUser = new Map<string, AgentUsageTableRow>();
+
+  for (const row of rows) {
+    if (!modelFilter(row.model)) {
+      continue;
+    }
+
+    const user = row.isNonCopilotUsage ? NON_COPILOT_CODE_REVIEW_LABEL : row.user;
+    const current = rowsByUser.get(user) ?? {
+      user,
+      quantity: 0,
+      gross: 0,
+      included: 0,
+      additional: 0,
+      quota: row.isNonCopilotUsage ? 0 : row.quotaValue ?? 'unknown',
+      isSyntheticNonCopilotRow: row.isNonCopilotUsage,
+    };
+
+    current.quantity += row.aicQuantity ?? row.billingQuantity ?? 0;
+    current.gross += row.grossAmount ?? row.aicGrossAmount ?? 0;
+    current.included += row.discountAmount ?? 0;
+    current.additional += row.netAmount ?? 0;
+    rowsByUser.set(user, current);
+  }
+
+  return Array.from(rowsByUser.values())
+    .filter((row) => row.quantity > 0 || row.gross > 0 || row.included > 0 || row.additional > 0)
+    .sort((left, right) => right.quantity - left.quantity);
+}
+
+function getVisibleRows<T extends { isSyntheticNonCopilotRow?: boolean }>(
+  rows: T[],
+  showAllRows: boolean,
+  previewCount: number
+): T[] {
+  if (showAllRows) {
+    return rows;
+  }
+
+  const preview = rows.slice(0, previewCount);
+  const syntheticRow = rows.find((row) => row.isSyntheticNonCopilotRow);
+
+  if (!syntheticRow || preview.some((row) => row.isSyntheticNonCopilotRow)) {
+    return preview;
+  }
+
+  return [...preview.slice(0, Math.max(0, previewCount - 1)), syntheticRow];
 }
 
 export function CodingAgentOverview({ 
@@ -25,45 +112,75 @@ export function CodingAgentOverview({
   const [showChart, setShowChart] = useState(true);
   const [showAllUsers, setShowAllUsers] = useState(false);
   const [showAllReviewUsers, setShowAllReviewUsers] = useState(false);
-  const { dailyBucketsArtifacts, selectedMonths } = useAnalysisContext();
+  const { aggregateProcessedData, dailyBucketsArtifacts, selectedMonths } = useAnalysisContext();
   const typedDailyBuckets = dailyBucketsArtifacts as DailyBucketsArtifacts | undefined;
-  
+  const hasAiCreditUsage = aggregateProcessedData.some((row) => row.usageUnit === 'ai_credit');
+  const hasRequestUsage = aggregateProcessedData.some((row) => row.usageUnit === 'request' && row.requestsUsed > 0);
+  const isUsageBasedBilling = hasAiCreditUsage && !hasRequestUsage;
+  const quantityColumnLabel = isUsageBasedBilling ? 'AI Credits' : 'Premium Requests';
+  const valueUnitLabel = isUsageBasedBilling ? 'AI Credits' : 'requests';
+  const costLabels = useMemo(() => getBillingCostLabels(isUsageBasedBilling), [isUsageBasedBilling]);
+   
   // Memoize daily coding agent data, filtered by selected billing months
   const dailyCodingAgentData = useMemo(() => {
-    if (typedDailyBuckets?.dailyUserModelTotals) {
-      const raw = buildDailyCodingAgentUsageFromArtifacts(typedDailyBuckets);
+    if (typedDailyBuckets) {
+      const raw = isUsageBasedBilling
+        ? buildDailyCodingAgentAicUsageFromArtifacts(typedDailyBuckets)
+        : buildDailyCodingAgentUsageFromArtifacts(typedDailyBuckets);
       return filterDailySeriesByMonths(raw, selectedMonths);
     }
     return [];
-  }, [typedDailyBuckets, selectedMonths]);
+  }, [isUsageBasedBilling, typedDailyBuckets, selectedMonths]);
 
   const dailyCodeReviewData = useMemo(() => {
-    if (typedDailyBuckets?.dailyUserModelTotals) {
-      const raw = buildDailyCodeReviewUsageFromArtifacts(typedDailyBuckets);
+    if (typedDailyBuckets) {
+      const raw = isUsageBasedBilling
+        ? buildDailyCodeReviewAicUsageFromArtifacts(typedDailyBuckets)
+        : buildDailyCodeReviewUsageFromArtifacts(typedDailyBuckets);
       return filterDailySeriesByMonths(raw, selectedMonths);
     }
     return [];
-  }, [typedDailyBuckets, selectedMonths]);
+  }, [isUsageBasedBilling, typedDailyBuckets, selectedMonths]);
 
   const TABLE_PREVIEW_COUNT = 5;
-  const visibleUsers = showAllUsers ? codingAgentUsers : codingAgentUsers.slice(0, TABLE_PREVIEW_COUNT);
-  const hasMore = codingAgentUsers.length > TABLE_PREVIEW_COUNT;
-
-  const visibleReviewUsers = useMemo(() => {
-    if (showAllReviewUsers) {
-      return codeReviewAnalysis.users;
+  const codingAgentTableRows = useMemo<AgentUsageTableRow[]>(() => {
+    if (isUsageBasedBilling) {
+      return buildUsageBasedAgentRows(aggregateProcessedData, isCodingAgentModel);
     }
 
-    const preview = codeReviewAnalysis.users.slice(0, TABLE_PREVIEW_COUNT);
-    const syntheticRow = codeReviewAnalysis.users.find((user) => user.isSyntheticNonCopilotRow);
+    return codingAgentUsers.map((user) => ({
+      user: user.user,
+      quantity: user.codingAgentRequests,
+      gross: 0,
+      included: 0,
+      additional: 0,
+      quota: user.quota,
+    }));
+  }, [aggregateProcessedData, codingAgentUsers, isUsageBasedBilling]);
 
-    if (!syntheticRow || preview.some((user) => user.isSyntheticNonCopilotRow)) {
-      return preview;
+  const codeReviewTableRows = useMemo<AgentUsageTableRow[]>(() => {
+    if (isUsageBasedBilling) {
+      return buildUsageBasedAgentRows(aggregateProcessedData, isCodeReviewModel);
     }
 
-    return [...preview.slice(0, Math.max(0, TABLE_PREVIEW_COUNT - 1)), syntheticRow];
-  }, [codeReviewAnalysis.users, showAllReviewUsers]);
-  const hasMoreReviewUsers = codeReviewAnalysis.users.length > TABLE_PREVIEW_COUNT;
+    return codeReviewAnalysis.users.map((user) => ({
+      user: user.user,
+      quantity: user.codeReviewRequests,
+      gross: 0,
+      included: 0,
+      additional: 0,
+      quota: user.quota,
+      isSyntheticNonCopilotRow: user.isSyntheticNonCopilotRow,
+    }));
+  }, [aggregateProcessedData, codeReviewAnalysis.users, isUsageBasedBilling]);
+
+  const visibleUsers = showAllUsers ? codingAgentTableRows : codingAgentTableRows.slice(0, TABLE_PREVIEW_COUNT);
+  const hasMore = codingAgentTableRows.length > TABLE_PREVIEW_COUNT;
+
+  const visibleReviewUsers = useMemo(() => (
+    getVisibleRows(codeReviewTableRows, showAllReviewUsers, TABLE_PREVIEW_COUNT)
+  ), [codeReviewTableRows, showAllReviewUsers]);
+  const hasMoreReviewUsers = codeReviewTableRows.length > TABLE_PREVIEW_COUNT;
 
   return (
     <div className="space-y-6">
@@ -89,9 +206,12 @@ export function CodingAgentOverview({
       {/* Chart */}
       {(!isMobile || showChart) && dailyCodingAgentData.length > 0 && (
         <div className="bg-white border border-[#d1d9e0] rounded-md p-5">
-          <h3 className="text-sm font-medium text-[#1f2328] mb-4">Usage Over Time</h3>
+          <h3 className="text-sm font-medium text-[#1f2328]">Usage Over Time</h3>
+          <p className="text-xs text-[#636c76] mt-0.5 mb-4">
+            Daily and cumulative {valueUnitLabel} usage
+          </p>
           <div className="h-56 sm:h-72">
-            <CodingAgentUsageChart data={dailyCodingAgentData} />
+            <CodingAgentUsageChart data={dailyCodingAgentData} valueUnitLabel={valueUnitLabel} />
           </div>
         </div>
       )}
@@ -110,11 +230,25 @@ export function CodingAgentOverview({
                     User
                   </th>
                   <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
-                    Premium Requests
+                    {quantityColumnLabel}
                   </th>
-                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
-                    Quota
-                  </th>
+                  {isUsageBasedBilling ? (
+                    <>
+                      <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
+                        {costLabels.gross}
+                      </th>
+                      <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
+                        {costLabels.discount}
+                      </th>
+                      <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
+                        {costLabels.net}
+                      </th>
+                    </>
+                  ) : (
+                    <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
+                      Quota
+                    </th>
+                  )}
                 </tr>
               </thead>
               <tbody className="divide-y divide-[#d1d9e0]">
@@ -124,11 +258,25 @@ export function CodingAgentOverview({
                       {user.user}
                     </td>
                     <td className="px-5 py-3 whitespace-nowrap text-sm font-mono text-[#1f2328] text-right">
-                      {user.codingAgentRequests.toFixed(1)}
+                      {formatUsageQuantity(user.quantity, isUsageBasedBilling)}
                     </td>
-                    <td className="px-5 py-3 whitespace-nowrap text-sm text-[#636c76] text-right">
-                      {user.quota === 'unknown' ? 'Unknown' : user.quota}
-                    </td>
+                    {isUsageBasedBilling ? (
+                      <>
+                        <td className="px-5 py-3 whitespace-nowrap text-sm font-mono text-[#636c76] text-right">
+                          {formatCurrency(user.gross)}
+                        </td>
+                        <td className="px-5 py-3 whitespace-nowrap text-sm font-mono text-emerald-600 text-right">
+                          -{formatCurrency(user.included)}
+                        </td>
+                        <td className="px-5 py-3 whitespace-nowrap text-sm font-mono font-semibold text-[#1f2328] text-right">
+                          {formatCurrency(user.additional)}
+                        </td>
+                      </>
+                    ) : (
+                      <td className="px-5 py-3 whitespace-nowrap text-sm text-[#636c76] text-right">
+                        {formatQuotaValue(user.quota)}
+                      </td>
+                    )}
                   </tr>
                 ))}
               </tbody>
@@ -140,7 +288,7 @@ export function CodingAgentOverview({
                 onClick={() => setShowAllUsers(!showAllUsers)}
                 className="text-sm font-medium text-indigo-600 hover:text-indigo-700 transition-colors"
               >
-                {showAllUsers ? `Show top ${TABLE_PREVIEW_COUNT}` : `Show all ${codingAgentUsers.length} users`}
+                {showAllUsers ? `Show top ${TABLE_PREVIEW_COUNT}` : `Show all ${codingAgentTableRows.length} users`}
               </button>
             </div>
           )}
@@ -160,9 +308,12 @@ export function CodingAgentOverview({
           {/* Code Review Chart */}
           {(!isMobile || showChart) && dailyCodeReviewData.length > 0 && (
             <div className="bg-white border border-[#d1d9e0] rounded-md p-5">
-              <h3 className="text-sm font-medium text-[#1f2328] mb-4">Usage Over Time</h3>
+              <h3 className="text-sm font-medium text-[#1f2328]">Usage Over Time</h3>
+              <p className="text-xs text-[#636c76] mt-0.5 mb-4">
+                Daily and cumulative {valueUnitLabel} usage
+              </p>
               <div className="h-56 sm:h-72">
-                <CodingAgentUsageChart data={dailyCodeReviewData} />
+                <CodingAgentUsageChart data={dailyCodeReviewData} valueUnitLabel={valueUnitLabel} />
               </div>
             </div>
           )}
@@ -178,16 +329,32 @@ export function CodingAgentOverview({
                   <thead>
                     <tr className="border-b border-[#d1d9e0]">
                       <th className="px-5 py-3 text-left text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">User</th>
-                      <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">Premium Requests</th>
-                      <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">Quota</th>
+                      <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">{quantityColumnLabel}</th>
+                      {isUsageBasedBilling ? (
+                        <>
+                          <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">{costLabels.gross}</th>
+                          <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">{costLabels.discount}</th>
+                          <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">{costLabels.net}</th>
+                        </>
+                      ) : (
+                        <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">Quota</th>
+                      )}
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-[#d1d9e0]">
                     {visibleReviewUsers.map((user) => (
                       <tr key={user.user} className="hover:bg-[#fcfdff] transition-colors">
                         <td className="px-5 py-3 whitespace-nowrap text-sm font-medium text-[#1f2328]">{user.user}</td>
-                        <td className="px-5 py-3 whitespace-nowrap text-sm font-mono text-[#1f2328] text-right">{user.codeReviewRequests.toFixed(1)}</td>
-                        <td className="px-5 py-3 whitespace-nowrap text-sm text-[#636c76] text-right">{user.quota === 'unknown' ? 'Unknown' : user.quota}</td>
+                        <td className="px-5 py-3 whitespace-nowrap text-sm font-mono text-[#1f2328] text-right">{formatUsageQuantity(user.quantity, isUsageBasedBilling)}</td>
+                        {isUsageBasedBilling ? (
+                          <>
+                            <td className="px-5 py-3 whitespace-nowrap text-sm font-mono text-[#636c76] text-right">{formatCurrency(user.gross)}</td>
+                            <td className="px-5 py-3 whitespace-nowrap text-sm font-mono text-emerald-600 text-right">-{formatCurrency(user.included)}</td>
+                            <td className="px-5 py-3 whitespace-nowrap text-sm font-mono font-semibold text-[#1f2328] text-right">{formatCurrency(user.additional)}</td>
+                          </>
+                        ) : (
+                          <td className="px-5 py-3 whitespace-nowrap text-sm text-[#636c76] text-right">{formatQuotaValue(user.quota)}</td>
+                        )}
                       </tr>
                     ))}
                   </tbody>
@@ -199,7 +366,7 @@ export function CodingAgentOverview({
                     onClick={() => setShowAllReviewUsers(!showAllReviewUsers)}
                     className="text-sm font-medium text-indigo-600 hover:text-indigo-700 transition-colors"
                   >
-                    {showAllReviewUsers ? `Show top ${TABLE_PREVIEW_COUNT}` : `Show all ${codeReviewAnalysis.users.length} users`}
+                    {showAllReviewUsers ? `Show top ${TABLE_PREVIEW_COUNT}` : `Show all ${codeReviewTableRows.length} users`}
                   </button>
                 </div>
               )}

--- a/src/components/CodingAgentOverview.tsx
+++ b/src/components/CodingAgentOverview.tsx
@@ -114,8 +114,14 @@ export function CodingAgentOverview({
   const [showAllReviewUsers, setShowAllReviewUsers] = useState(false);
   const { aggregateProcessedData, dailyBucketsArtifacts, selectedMonths } = useAnalysisContext();
   const typedDailyBuckets = dailyBucketsArtifacts as DailyBucketsArtifacts | undefined;
-  const hasAiCreditUsage = aggregateProcessedData.some((row) => row.usageUnit === 'ai_credit');
-  const hasRequestUsage = aggregateProcessedData.some((row) => row.usageUnit === 'request' && row.requestsUsed > 0);
+  const hasAiCreditUsage = useMemo(
+    () => aggregateProcessedData.some((row) => row.usageUnit === 'ai_credit'),
+    [aggregateProcessedData]
+  );
+  const hasRequestUsage = useMemo(
+    () => aggregateProcessedData.some((row) => row.usageUnit === 'request' && row.requestsUsed > 0),
+    [aggregateProcessedData]
+  );
   const isUsageBasedBilling = hasAiCreditUsage && !hasRequestUsage;
   const quantityColumnLabel = isUsageBasedBilling ? 'AI Credits' : 'Premium Requests';
   const valueUnitLabel = isUsageBasedBilling ? 'AI Credits' : 'requests';

--- a/src/components/DataAnalysis.tsx
+++ b/src/components/DataAnalysis.tsx
@@ -579,7 +579,9 @@ function DataAnalysisInner() {
                     <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
                       <div>
                         <h3 className="text-lg font-semibold text-[#1f2328]">Auto Mode Savings</h3>
-                        <p className="text-sm text-[#636c76] mt-0.5">Savings compare billed cost with the cost before Auto Mode&apos;s 10% PRU discount.</p>
+                        <p className="text-sm text-[#636c76] mt-0.5">
+                          Savings compare billed cost with the cost before Auto Mode&apos;s 10% {isUsageBasedBilling ? 'AI Credits' : 'PRU'} discount.
+                        </p>
                       </div>
                       <span className="text-sm font-semibold text-[#2da44e]">
                         {formatCurrency(autoModeSavingsTotal.savings)} saved

--- a/src/components/DataAnalysis.tsx
+++ b/src/components/DataAnalysis.tsx
@@ -289,11 +289,11 @@ function DataAnalysisInner() {
   const autoModeSavingsTotal = useMemo(() => {
     return autoModeSavingsRows.reduce(
       (total, row) => ({
-        requests: total.requests + row.requests,
+        quantity: total.quantity + row.quantity,
         costBeforeAuto: total.costBeforeAuto + row.costBeforeAuto,
         savings: total.savings + row.savings,
       }),
-      { requests: 0, costBeforeAuto: 0, savings: 0 }
+      { quantity: 0, costBeforeAuto: 0, savings: 0 }
     );
   }, [autoModeSavingsRows]);
 
@@ -602,7 +602,7 @@ function DataAnalysisInner() {
                         {autoModeSavingsRows.map((item) => (
                           <tr key={item.model} className="table-row-hover transition-colors duration-150">
                             <td className="px-6 py-3.5 text-sm font-medium text-[#1f2328]">{item.model}</td>
-                            <td className="px-6 py-3.5 text-sm text-[#636c76] text-right font-mono">{item.requests.toFixed(2)}</td>
+                            <td className="px-6 py-3.5 text-sm text-[#636c76] text-right font-mono">{item.quantity.toFixed(2)}</td>
                             <td className="px-6 py-3.5 text-sm text-[#636c76] text-right font-mono">{formatCurrency(item.costBeforeAuto)}</td>
                             <td className="px-6 py-3.5 text-sm font-semibold text-[#2da44e] text-right font-mono">{formatCurrency(item.savings)}</td>
                           </tr>
@@ -611,7 +611,7 @@ function DataAnalysisInner() {
                       <tfoot>
                         <tr className="border-t-2 border-[#d1d9e0] bg-[#f6f8fa]">
                           <td className="px-6 py-3.5 text-sm font-bold text-[#1f2328]">Total</td>
-                          <td className="px-6 py-3.5 text-sm font-bold text-[#1f2328] text-right font-mono">{autoModeSavingsTotal.requests.toFixed(2)}</td>
+                          <td className="px-6 py-3.5 text-sm font-bold text-[#1f2328] text-right font-mono">{autoModeSavingsTotal.quantity.toFixed(2)}</td>
                           <td className="px-6 py-3.5 text-sm font-bold text-[#1f2328] text-right font-mono">{formatCurrency(autoModeSavingsTotal.costBeforeAuto)}</td>
                           <td className="px-6 py-3.5 text-sm font-bold text-[#2da44e] text-right font-mono">{formatCurrency(autoModeSavingsTotal.savings)}</td>
                         </tr>

--- a/src/components/charts/CodingAgentUsageChart.tsx
+++ b/src/components/charts/CodingAgentUsageChart.tsx
@@ -7,7 +7,7 @@ import { chartTooltipContentStyle, chartTooltipLabelStyle, utcDateTickFormatter 
 
 export interface CodingAgentUsageDatum {
   date: string;              // YYYY-MM-DD (UTC original date fragment)
-  dailyRequests: number;     // requests that day
+  dailyRequests: number;     // usage that day
   cumulativeRequests: number;// cumulative total up to that day
 }
 
@@ -16,9 +16,13 @@ type ResponsiveHeight = number | `${number}%`;
 interface CodingAgentUsageChartProps {
   data: CodingAgentUsageDatum[];
   height?: ResponsiveHeight;
+  valueUnitLabel?: string;
 }
 
-export function CodingAgentUsageChart({ data, height = '100%' }: CodingAgentUsageChartProps) {
+export function CodingAgentUsageChart({ data, height = '100%', valueUnitLabel = 'requests' }: CodingAgentUsageChartProps) {
+  const dailyLabel = valueUnitLabel === 'AI Credits' ? 'Daily AI Credits' : 'Daily Requests';
+  const cumulativeLabel = valueUnitLabel === 'AI Credits' ? 'Cumulative AI Credits' : 'Cumulative Requests';
+
   return (
     <ResponsiveContainer width="100%" height={height}>
       <LineChart data={data}>
@@ -35,8 +39,8 @@ export function CodingAgentUsageChart({ data, height = '100%' }: CodingAgentUsag
             return date.toLocaleDateString('en-US', { timeZone: 'UTC' });
           }}
           formatter={(value, name) => [
-            `${Number(value).toFixed(1)} requests`,
-            name === 'Daily Requests' ? 'Daily' : 'Cumulative'
+            `${Number(value).toFixed(1)} ${valueUnitLabel}`,
+            name === dailyLabel ? 'Daily' : 'Cumulative'
           ]}
           contentStyle={chartTooltipContentStyle}
           labelStyle={chartTooltipLabelStyle}
@@ -49,7 +53,7 @@ export function CodingAgentUsageChart({ data, height = '100%' }: CodingAgentUsag
           strokeWidth={2}
           dot={{ r: 3 }}
           activeDot={{ r: 5 }}
-          name="Cumulative Requests"
+          name={cumulativeLabel}
         />
         <Line
           type="monotone"
@@ -58,7 +62,7 @@ export function CodingAgentUsageChart({ data, height = '100%' }: CodingAgentUsag
           strokeWidth={2}
           dot={{ r: 3 }}
           activeDot={{ r: 5 }}
-          name="Daily Requests"
+          name={dailyLabel}
         />
       </LineChart>
     </ResponsiveContainer>

--- a/src/utils/autoModeSavings.ts
+++ b/src/utils/autoModeSavings.ts
@@ -6,7 +6,7 @@ const COST_BEFORE_AUTO_MULTIPLIER = 1 + PRICING.AUTO_MODE_DISCOUNT_RATE;
 
 export interface AutoModeSavingsRow {
   model: string;
-  requests: number;
+  quantity: number;
   costBeforeAuto: number;
   savings: number;
 }
@@ -21,7 +21,7 @@ function getBilledQuantity(row: ProcessedData): number {
 
 function getUnitCost(row: ProcessedData): number {
   if (row.usageUnit === 'ai_credit') {
-    return PRICING.AI_CREDIT_USD_VALUE;
+    return row.appliedCostPerQuantity ?? PRICING.AI_CREDIT_USD_VALUE;
   }
 
   return row.appliedCostPerQuantity ?? PRICING.OVERAGE_RATE_PER_REQUEST;
@@ -52,12 +52,12 @@ export function aggregateAutoModeSavings(rows: ProcessedData[]): AutoModeSavings
     const savings = costBeforeAuto - billedGrossAmount;
     const bucket = buckets.get(model) ?? {
       model,
-      requests: 0,
+      quantity: 0,
       costBeforeAuto: 0,
       savings: 0,
     };
 
-    bucket.requests += billedQuantity;
+    bucket.quantity += billedQuantity;
     bucket.costBeforeAuto += costBeforeAuto;
     bucket.savings += savings;
     buckets.set(model, bucket);

--- a/src/utils/autoModeSavings.ts
+++ b/src/utils/autoModeSavings.ts
@@ -2,13 +2,29 @@ import { PRICING } from '@/constants/pricing';
 import type { ProcessedData } from '@/types/csv';
 
 const AUTO_MODE_MODEL_PREFIX = /^auto:\s*/i;
-const AUTO_MODE_PRU_MULTIPLIER = 1 - PRICING.AUTO_MODE_DISCOUNT_RATE;
+const COST_BEFORE_AUTO_MULTIPLIER = 1 + PRICING.AUTO_MODE_DISCOUNT_RATE;
 
 export interface AutoModeSavingsRow {
   model: string;
   requests: number;
   costBeforeAuto: number;
   savings: number;
+}
+
+function getBilledQuantity(row: ProcessedData): number {
+  if (row.usageUnit === 'ai_credit') {
+    return row.aicQuantity ?? row.billingQuantity ?? 0;
+  }
+
+  return row.requestsUsed;
+}
+
+function getUnitCost(row: ProcessedData): number {
+  if (row.usageUnit === 'ai_credit') {
+    return PRICING.AI_CREDIT_USD_VALUE;
+  }
+
+  return row.appliedCostPerQuantity ?? PRICING.OVERAGE_RATE_PER_REQUEST;
 }
 
 export function getAutoModeBaseModel(model: string): string | null {
@@ -24,20 +40,15 @@ export function aggregateAutoModeSavings(rows: ProcessedData[]): AutoModeSavings
   const buckets = new Map<string, AutoModeSavingsRow>();
 
   for (const row of rows) {
-    if (row.usageUnit === 'ai_credit') {
-      continue;
-    }
-
     const model = getAutoModeBaseModel(row.model);
 
     if (!model) {
       continue;
     }
 
-    const appliedCostPerRequest = row.appliedCostPerQuantity ?? PRICING.OVERAGE_RATE_PER_REQUEST;
-    const requests = row.requestsUsed / AUTO_MODE_PRU_MULTIPLIER;
-    const billedGrossAmount = row.grossAmount ?? row.requestsUsed * appliedCostPerRequest;
-    const costBeforeAuto = billedGrossAmount / AUTO_MODE_PRU_MULTIPLIER;
+    const billedQuantity = getBilledQuantity(row);
+    const billedGrossAmount = row.grossAmount ?? billedQuantity * getUnitCost(row);
+    const costBeforeAuto = billedGrossAmount * COST_BEFORE_AUTO_MULTIPLIER;
     const savings = costBeforeAuto - billedGrossAmount;
     const bucket = buckets.get(model) ?? {
       model,
@@ -46,7 +57,7 @@ export function aggregateAutoModeSavings(rows: ProcessedData[]): AutoModeSavings
       savings: 0,
     };
 
-    bucket.requests += requests;
+    bucket.requests += billedQuantity;
     bucket.costBeforeAuto += costBeforeAuto;
     bucket.savings += savings;
     buckets.set(model, bucket);

--- a/src/utils/ingestion/analytics.ts
+++ b/src/utils/ingestion/analytics.ts
@@ -554,17 +554,17 @@ export function buildAdvisoriesFromArtifacts(
 // -----------------------------
 /**
  * Shared implementation for building a daily usage time series filtered to a
- * subset of models. Iterates dailyUserModelTotals, sums per-model quantities for
- * models matching the predicate, includes only days with > 0 requests, sorts by
+ * subset of models. Iterates the provided daily user/model map, sums per-model quantities for
+ * models matching the predicate, includes only days with > 0 usage, sorts by
  * ascending date, and computes a running cumulative total.
  */
 function buildDailyModelSubsetUsageFromArtifacts(
-  daily: DailyBucketsArtifacts,
+  dailyUserModelTotals: Map<string, Map<string, Map<string, number>>> | undefined,
   modelFilter: (model: string) => boolean
 ): DailyCodingAgentUsageDatum[] {
-  if (!daily.dailyUserModelTotals) return [];
+  if (!dailyUserModelTotals) return [];
   const dayTotals: Array<{ date: string; total: number }> = [];
-  for (const [date, userMap] of daily.dailyUserModelTotals.entries()) {
+  for (const [date, userMap] of dailyUserModelTotals.entries()) {
     let daySum = 0;
     for (const modelMap of userMap.values()) {
       for (const [model, qty] of modelMap.entries()) {
@@ -597,7 +597,13 @@ function buildDailyModelSubsetUsageFromArtifacts(
 export function buildDailyCodingAgentUsageFromArtifacts(
   daily: DailyBucketsArtifacts
 ): DailyCodingAgentUsageDatum[] {
-  return buildDailyModelSubsetUsageFromArtifacts(daily, isCodingAgentModel);
+  return buildDailyModelSubsetUsageFromArtifacts(daily.dailyUserModelTotals, isCodingAgentModel);
+}
+
+export function buildDailyCodingAgentAicUsageFromArtifacts(
+  daily: DailyBucketsArtifacts
+): DailyCodingAgentUsageDatum[] {
+  return buildDailyModelSubsetUsageFromArtifacts(daily.dailyUserAicModelTotals, isCodingAgentModel);
 }
 
 // -----------------------------
@@ -658,7 +664,13 @@ export function analyzeCodeReviewAdoptionFromArtifacts(usage: UsageArtifacts, qu
 export function buildDailyCodeReviewUsageFromArtifacts(
   daily: DailyBucketsArtifacts
 ): DailyCodingAgentUsageDatum[] {
-  return buildDailyModelSubsetUsageFromArtifacts(daily, isCodeReviewModel);
+  return buildDailyModelSubsetUsageFromArtifacts(daily.dailyUserModelTotals, isCodeReviewModel);
+}
+
+export function buildDailyCodeReviewAicUsageFromArtifacts(
+  daily: DailyBucketsArtifacts
+): DailyCodingAgentUsageDatum[] {
+  return buildDailyModelSubsetUsageFromArtifacts(daily.dailyUserAicModelTotals, isCodeReviewModel);
 }
 
 // -----------------------------


### PR DESCRIPTION
Usage-based billing reports should preserve the agent usage views and Auto Mode savings context that reviewers expect from request-based reports. This PR restores those surfaces with AI Credit-aware quantities and cost labels.

## Summary

| Commit | Change |
|--------|--------|
| `feat: show AI Credits agent usage` | Restores daily and cumulative Cloud Agent and Code Review charts for usage-based reports, switches agent tables to AI Credits, and adds usage-based cost columns aligned with the rest of the app. |
| `fix: correct Auto Mode AI Credits savings` | Shows Auto Mode savings for AI Credit reports and calculates Cost Before Auto as 10% higher than the consumed Auto Mode AI Credits cost while keeping the quantity column as consumed credits. |

## Validation

- `npm run build && npm run lint && npm test -- --runInBand`

## Notes

- Lint completes with the existing unrelated `react-hooks/exhaustive-deps` warning in `src/components/insights/AdvisorySection.tsx`.
- No source issue was provided.