### PR TITLE
fix: show AI credits in usage-based tables

### DIFF
--- a/__tests__/components/DataAnalysisBilling.test.tsx
+++ b/__tests__/components/DataAnalysisBilling.test.tsx
@@ -417,6 +417,22 @@ describe('DataAnalysis billing summary', () => {
         organization: 'test-org-one',
         cost_center_name: 'test-cost-center-one',
       },
+      {
+        date: '2026-06-01',
+        username: 'test-user-two',
+        product: 'copilot',
+        sku: 'copilot_premium_request',
+        model: 'Auto: Claude Haiku 4.5',
+        quantity: '3',
+        unit_type: 'requests',
+        applied_cost_per_quantity: '0.04',
+        gross_amount: '0.12',
+        discount_amount: '0',
+        net_amount: '0.12',
+        total_monthly_quota: '300',
+        organization: 'test-org-one',
+        cost_center_name: 'test-cost-center-one',
+      },
     ];
 
     const ingestionResult = createIngestionResultFromRawRows(usageBasedRows);
@@ -443,17 +459,35 @@ describe('DataAnalysis billing summary', () => {
       expect(screen.queryAllByRole('button', { name: 'Cost Optimization' })).toHaveLength(0);
     });
 
+    const productHeader = screen.getByRole('columnheader', { name: 'Product' });
+    const productTable = productHeader.closest('table');
+    expect(productTable).not.toBeNull();
+    expect(within(productTable!).getByRole('columnheader', { name: 'Total AI Credits' })).toBeInTheDocument();
+    expect(within(productTable!).queryByRole('columnheader', { name: 'Requests' })).not.toBeInTheDocument();
+    expect(within(productTable!).queryByRole('columnheader', { name: 'AI Credits Gross' })).not.toBeInTheDocument();
+
+    const autoModeSavingsHeading = screen.getByRole('heading', { name: 'Auto Mode Savings' });
+    const autoModeSavingsCard = autoModeSavingsHeading.closest('.bg-white');
+    expect(autoModeSavingsCard).not.toBeNull();
+    const autoModeSavingsTable = within(autoModeSavingsCard as HTMLElement).getByRole('table');
+    expect(within(autoModeSavingsTable).getByRole('columnheader', { name: 'Total AI Credits' })).toBeInTheDocument();
+    expect(within(autoModeSavingsTable).queryByRole('columnheader', { name: 'Requests' })).not.toBeInTheDocument();
+    expect(within(autoModeSavingsTable).getAllByText('42.50').length).toBeGreaterThan(0);
+    expect(within(autoModeSavingsTable).queryByText('45.50')).not.toBeInTheDocument();
+
     const modelDetailsHeading = screen.getByRole('heading', { name: 'Model Details' });
     const modelDetailsCard = modelDetailsHeading.closest('.bg-white');
     expect(modelDetailsCard).not.toBeNull();
     const modelDetailsTable = within(modelDetailsCard as HTMLElement).getByRole('table');
-    expect(within(modelDetailsTable).getByRole('columnheader', { name: 'AI Credits' })).toBeInTheDocument();
+    expect(within(modelDetailsTable).getByRole('columnheader', { name: 'Total AI Credits' })).toBeInTheDocument();
     expect(within(modelDetailsTable).getByRole('columnheader', { name: 'Gross Amount' })).toBeInTheDocument();
     expect(within(modelDetailsTable).getByRole('columnheader', { name: 'Included Credits' })).toBeInTheDocument();
     expect(within(modelDetailsTable).getByRole('columnheader', { name: 'Additional usage' })).toBeInTheDocument();
     expect(within(modelDetailsTable).queryByRole('columnheader', { name: 'Requests' })).not.toBeInTheDocument();
     expect(within(modelDetailsTable).queryByRole('columnheader', { name: 'AI Credits Gross' })).not.toBeInTheDocument();
     expect(within(modelDetailsTable).queryByRole('columnheader', { name: 'Gross' })).not.toBeInTheDocument();
+    expect(within(modelDetailsTable).getByText('42.50')).toBeInTheDocument();
+    expect(within(modelDetailsTable).queryByText('45.50')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Models' })[0]);
 

--- a/src/components/CodingAgentOverview.tsx
+++ b/src/components/CodingAgentOverview.tsx
@@ -118,11 +118,7 @@ export function CodingAgentOverview({
     () => aggregateProcessedData.some((row) => row.usageUnit === 'ai_credit'),
     [aggregateProcessedData]
   );
-  const hasRequestUsage = useMemo(
-    () => aggregateProcessedData.some((row) => row.usageUnit === 'request' && row.requestsUsed > 0),
-    [aggregateProcessedData]
-  );
-  const isUsageBasedBilling = hasAiCreditUsage && !hasRequestUsage;
+  const isUsageBasedBilling = hasAiCreditUsage;
   const quantityColumnLabel = isUsageBasedBilling ? 'AI Credits' : 'Premium Requests';
   const valueUnitLabel = isUsageBasedBilling ? 'AI Credits' : 'requests';
   const costLabels = useMemo(() => getBillingCostLabels(isUsageBasedBilling), [isUsageBasedBilling]);

--- a/src/components/CostCentersOverview.tsx
+++ b/src/components/CostCentersOverview.tsx
@@ -1,25 +1,37 @@
 'use client';
 
+import { useMemo } from 'react';
+
 import { BillingGroupTable, useBillingGroupRows } from '@/components/BillingGroupTable';
 import { useAnalysisContext } from '@/context/AnalysisContext';
 import { getBillingCostLabels } from '@/utils/billingLabels';
-import { UNASSIGNED_BILLING_GROUP } from '@/utils/ingestion';
+import { buildBillingArtifactsFromProcessedData, UNASSIGNED_BILLING_GROUP } from '@/utils/ingestion';
 
 export function CostCentersOverview() {
   const { aggregateProcessedData, billingArtifacts } = useAnalysisContext();
+  const isUsageBasedBilling = aggregateProcessedData.some((row) => row.usageUnit === 'ai_credit');
+  const billingRows = useMemo(
+    () => isUsageBasedBilling
+      ? aggregateProcessedData.filter((row) => row.usageUnit === 'ai_credit')
+      : aggregateProcessedData,
+    [aggregateProcessedData, isUsageBasedBilling]
+  );
+  const scopedBillingArtifacts = useMemo(
+    () => billingArtifacts && isUsageBasedBilling
+      ? buildBillingArtifactsFromProcessedData(billingRows)
+      : billingArtifacts,
+    [billingArtifacts, billingRows, isUsageBasedBilling]
+  );
 
   const costCenterRows = useBillingGroupRows({
-    sourceRows: aggregateProcessedData,
+    sourceRows: billingRows,
     getGroupName: (row) => row.costCenter || UNASSIGNED_BILLING_GROUP,
-    getTotals: (name) => billingArtifacts?.costCenterTotals.get(name),
+    getTotals: (name) => scopedBillingArtifacts?.costCenterTotals.get(name),
   });
 
   const hasCosts = costCenterRows.some(r => r.gross > 0 || r.net > 0);
-  const hasAicGross = billingArtifacts?.hasAnyAicData === true;
-  const hasAiCreditUsage = aggregateProcessedData.some((row) => row.usageUnit === 'ai_credit');
-  const hasRequestUsage = aggregateProcessedData.some((row) => row.usageUnit === 'request' && row.requestsUsed > 0);
-  const isUsageBasedBilling = hasAiCreditUsage && !hasRequestUsage;
-  const quantityColumnLabel = isUsageBasedBilling ? 'AI Credits' : 'Requests';
+  const hasAicGross = scopedBillingArtifacts?.hasAnyAicData === true;
+  const quantityColumnLabel = isUsageBasedBilling ? 'Total AI Credits' : 'Requests';
   const costLabels = getBillingCostLabels(isUsageBasedBilling);
 
   return (

--- a/src/components/DataAnalysis.tsx
+++ b/src/components/DataAnalysis.tsx
@@ -7,6 +7,7 @@ import { AnalysisProvider, useAnalysisContext } from '@/context/AnalysisContext'
 import { aggregateAutoModeSavings } from '@/utils/autoModeSavings';
 import { getBillingCostLabels } from '@/utils/billingLabels';
 import { formatCurrency } from '@/utils/formatters';
+import { buildBillingArtifactsFromProcessedData } from '@/utils/ingestion';
 import { getModelColor } from '@/utils/modelColors';
 import { aggregateProductCosts } from '@/utils/productCosts';
 
@@ -164,12 +165,20 @@ function DataAnalysisInner() {
     () => aggregateProcessedData.some((row) => row.usageUnit === 'ai_credit'),
     [aggregateProcessedData]
   );
-  const hasRequestUsage = useMemo(
-    () => aggregateProcessedData.some((row) => row.usageUnit === 'request' && row.requestsUsed > 0),
-    [aggregateProcessedData]
+  const isUsageBasedBilling = hasAiCreditUsage;
+  const usageBasedRows = useMemo(
+    () => isUsageBasedBilling
+      ? aggregateProcessedData.filter((row) => row.usageUnit === 'ai_credit')
+      : aggregateProcessedData,
+    [aggregateProcessedData, isUsageBasedBilling]
   );
-  const isUsageBasedBilling = hasAiCreditUsage && !hasRequestUsage;
-  const quantityColumnLabel = isUsageBasedBilling ? 'AI Credits' : 'Requests';
+  const usageBasedBillingArtifacts = useMemo(
+    () => billingArtifacts && isUsageBasedBilling
+      ? buildBillingArtifactsFromProcessedData(usageBasedRows)
+      : billingArtifacts,
+    [billingArtifacts, isUsageBasedBilling, usageBasedRows]
+  );
+  const quantityColumnLabel = isUsageBasedBilling ? 'Total AI Credits' : 'Requests';
   const billingQuantityLabel = isUsageBasedBilling ? 'AI Credits' : 'PRUs';
   const costLabels = getBillingCostLabels(isUsageBasedBilling);
   const unitCostLabel = isUsageBasedBilling
@@ -236,11 +245,11 @@ function DataAnalysisInner() {
   );
 
   const modelRows = useMemo(() => {
-    if (billingArtifacts) {
-      return Array.from(billingArtifacts.billingByModel.entries())
+    if (usageBasedBillingArtifacts) {
+      return Array.from(usageBasedBillingArtifacts.billingByModel.entries())
         .map(([model, totals]) => ({
           model,
-          requests: totals.quantity,
+          requests: isUsageBasedBilling ? totals.aicQuantity : totals.quantity,
           gross: totals.gross,
           discount: totals.discount,
           net: totals.net,
@@ -257,7 +266,7 @@ function DataAnalysisInner() {
       net: 0,
       aicGrossAmount: 0,
     }));
-  }, [analysis.requestsByModel, billingArtifacts]);
+  }, [analysis.requestsByModel, isUsageBasedBilling, usageBasedBillingArtifacts]);
 
   const hasModelCosts = modelRows.some(
     (row) => row.gross > 0 || row.discount > 0 || row.net > 0
@@ -279,12 +288,12 @@ function DataAnalysisInner() {
     ? modelChartTotal.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
     : modelChartTotal.toFixed(0);
 
-  const productCosts = useMemo(() => aggregateProductCosts(aggregateProcessedData), [aggregateProcessedData]);
-  const showProductAicGross = aicMetricsAvailable;
+  const productCosts = useMemo(() => aggregateProductCosts(usageBasedRows), [usageBasedRows]);
+  const showProductAicGross = aicMetricsAvailable && !isUsageBasedBilling;
   const showProductCosts = costMetricsAvailable;
   const autoModeSavingsRows = useMemo(
-    () => aggregateAutoModeSavings(aggregateProcessedData),
-    [aggregateProcessedData]
+    () => aggregateAutoModeSavings(usageBasedRows),
+    [usageBasedRows]
   );
   const autoModeSavingsTotal = useMemo(() => {
     return autoModeSavingsRows.reduce(
@@ -554,7 +563,9 @@ function DataAnalysisInner() {
                         {productCosts.map((product) => (
                           <tr key={product.label} className="table-row-hover transition-colors duration-150">
                             <td className="px-6 py-3.5 text-sm font-medium text-[#1f2328]">{product.label}</td>
-                            <td className="px-6 py-3.5 text-sm text-[#636c76] text-right font-mono">{product.requests.toFixed(2)}</td>
+                            <td className="px-6 py-3.5 text-sm text-[#636c76] text-right font-mono">
+                              {(isUsageBasedBilling ? product.aicQuantity : product.requests).toFixed(2)}
+                            </td>
                             {showProductAicGross && (
                               <td className="px-6 py-3.5 text-sm text-[#636c76] text-right font-mono">{formatCurrency(product.aicGrossAmount)}</td>
                             )}

--- a/src/components/ModelUsageTrendsOverview.tsx
+++ b/src/components/ModelUsageTrendsOverview.tsx
@@ -84,9 +84,7 @@ export function ModelUsageTrendsOverview() {
     aggregateProcessedData,
   } = useAnalysisContext();
   const isUsageBasedBilling = useMemo(() => {
-    const hasAiCreditUsage = aggregateProcessedData.some((row) => row.usageUnit === 'ai_credit');
-    const hasRequestUsage = aggregateProcessedData.some((row) => row.usageUnit === 'request' && row.requestsUsed > 0);
-    return hasAiCreditUsage && !hasRequestUsage;
+    return aggregateProcessedData.some((row) => row.usageUnit === 'ai_credit');
   }, [aggregateProcessedData]);
 
   const { data, models } = useMemo(() => {

--- a/src/components/OrganizationsOverview.tsx
+++ b/src/components/OrganizationsOverview.tsx
@@ -1,9 +1,11 @@
 'use client';
 
+import { useMemo } from 'react';
+
 import { BillingGroupEntry, BillingGroupRow, BillingGroupTable, useBillingGroupRows } from '@/components/BillingGroupTable';
 import { useAnalysisContext } from '@/context/AnalysisContext';
 import { getBillingCostLabels } from '@/utils/billingLabels';
-import { UNASSIGNED_BILLING_GROUP } from '@/utils/ingestion';
+import { buildBillingArtifactsFromProcessedData, UNASSIGNED_BILLING_GROUP } from '@/utils/ingestion';
 
 interface OrganizationRow extends BillingGroupRow {
   users: number;
@@ -11,11 +13,24 @@ interface OrganizationRow extends BillingGroupRow {
 
 export function OrganizationsOverview() {
   const { aggregateProcessedData, billingArtifacts } = useAnalysisContext();
+  const isUsageBasedBilling = aggregateProcessedData.some((row) => row.usageUnit === 'ai_credit');
+  const billingRows = useMemo(
+    () => isUsageBasedBilling
+      ? aggregateProcessedData.filter((row) => row.usageUnit === 'ai_credit')
+      : aggregateProcessedData,
+    [aggregateProcessedData, isUsageBasedBilling]
+  );
+  const scopedBillingArtifacts = useMemo(
+    () => billingArtifacts && isUsageBasedBilling
+      ? buildBillingArtifactsFromProcessedData(billingRows)
+      : billingArtifacts,
+    [billingArtifacts, billingRows, isUsageBasedBilling]
+  );
 
   const orgRows = useBillingGroupRows<{ users: number }>({
-    sourceRows: aggregateProcessedData,
+    sourceRows: billingRows,
     getGroupName: (row) => row.organization || UNASSIGNED_BILLING_GROUP,
-    getTotals: (name) => billingArtifacts?.orgTotals.get(name),
+    getTotals: (name) => scopedBillingArtifacts?.orgTotals.get(name),
     updateEntry: (entry: BillingGroupEntry, row) => {
       if (!row.isNonCopilotUsage) {
         entry.users ??= new Set<string>();
@@ -26,11 +41,8 @@ export function OrganizationsOverview() {
   });
 
   const hasCosts = orgRows.some(r => r.gross > 0 || r.net > 0);
-  const hasAicGross = billingArtifacts?.hasAnyAicData === true;
-  const hasAiCreditUsage = aggregateProcessedData.some((row) => row.usageUnit === 'ai_credit');
-  const hasRequestUsage = aggregateProcessedData.some((row) => row.usageUnit === 'request' && row.requestsUsed > 0);
-  const isUsageBasedBilling = hasAiCreditUsage && !hasRequestUsage;
-  const quantityColumnLabel = isUsageBasedBilling ? 'AI Credits' : 'Requests';
+  const hasAicGross = scopedBillingArtifacts?.hasAnyAicData === true;
+  const quantityColumnLabel = isUsageBasedBilling ? 'Total AI Credits' : 'Requests';
   const costLabels = getBillingCostLabels(isUsageBasedBilling);
 
   return (

--- a/src/components/UsersOverview.tsx
+++ b/src/components/UsersOverview.tsx
@@ -87,9 +87,7 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, da
 
   const hasAicGross = effectiveBillingArtifacts.hasAnyAicData;
   const isUsageBasedBilling = useMemo(() => {
-    const hasAiCreditUsage = processedData.some((row) => row.usageUnit === 'ai_credit');
-    const hasRequestUsage = processedData.some((row) => row.usageUnit === 'request' && row.requestsUsed > 0);
-    return hasAiCreditUsage && !hasRequestUsage;
+    return processedData.some((row) => row.usageUnit === 'ai_credit');
   }, [processedData]);
   const showRequestMetrics = !isUsageBasedBilling;
   const showAicGross = hasAicGross && !isUsageBasedBilling;


### PR DESCRIPTION
## Summary

Fixes usage-based reports that include AI-credit rows alongside request rows so the overview billing tables remain in AI-credit mode.

| Commit | Change |
|--------|--------|
| `fix: show AI credits in usage-based tables` | Treat reports with AI-credit usage as usage-based, scope overview/grouped billing totals to AI-credit rows, and add regression coverage for mixed AI-credit/request data. |

## Validation

- `npm run build`
- `npm run lint`
- `npm run test`