### PR TITLE
Add AI usage concentration tables

### DIFF
--- a/__tests__/utils/aicFields.test.ts
+++ b/__tests__/utils/aicFields.test.ts
@@ -1,8 +1,23 @@
-import { hasAicFields } from '@/utils/aicFields';
+import { getEffectiveAicQuantity, hasAicFields } from '@/utils/aicFields';
 
 describe('hasAicFields', () => {
   it('requires AI Credits gross to be present', () => {
     expect(hasAicFields([{ aicQuantity: 10 }])).toBe(false);
     expect(hasAicFields([{ aicGrossAmount: 0 }])).toBe(true);
+  });
+});
+
+describe('getEffectiveAicQuantity', () => {
+  it('uses the larger value when gross amount implies more credits than quantity', () => {
+    expect(getEffectiveAicQuantity({ aicQuantity: 5, aicGrossAmount: 0.5 })).toBe(50);
+  });
+
+  it('preserves quantity when it is larger than the value derived from gross amount', () => {
+    expect(getEffectiveAicQuantity({ aicQuantity: 75, aicGrossAmount: 0.5 })).toBe(75);
+  });
+
+  it('falls back to gross amount or zero when quantity is absent', () => {
+    expect(getEffectiveAicQuantity({ aicGrossAmount: 0.25 })).toBe(25);
+    expect(getEffectiveAicQuantity({})).toBe(0);
   });
 });

--- a/src/components/AiUsageOverview.tsx
+++ b/src/components/AiUsageOverview.tsx
@@ -1,11 +1,106 @@
 'use client';
 
+import { useMemo } from 'react';
+
+import { PRICING } from '@/constants/pricing';
 import { useAnalysisContext } from '@/context/AnalysisContext';
+import type { BillingUserTotals } from '@/utils/ingestion';
 
 import { UsersAicClustersChart } from './charts/UsersAicClustersChart';
 
+interface RankedAicUser {
+  user: string;
+  aiCredits: number;
+  shareOfTotal: number;
+}
+
+interface AicConcentrationRow {
+  concentration: string;
+  users: number;
+  shareOfAicCredits: number;
+  aiCredits: number;
+}
+
+function formatPercentage(value: number): string {
+  return `${value.toFixed(1)}%`;
+}
+
+function formatAiCredits(value: number): string {
+  return value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+function getConsumedAiCredits(user: BillingUserTotals): number {
+  if (typeof user.aicQuantity === 'number') {
+    return user.aicQuantity;
+  }
+
+  return typeof user.aicGrossAmount === 'number'
+    ? user.aicGrossAmount / PRICING.AI_CREDIT_USD_VALUE
+    : 0;
+}
+
+function buildRankedAicUsers(users: BillingUserTotals[]): RankedAicUser[] {
+  const totalAiCredits = users.reduce((sum, user) => sum + getConsumedAiCredits(user), 0);
+
+  return users
+    .map((user) => {
+      const aiCredits = getConsumedAiCredits(user);
+
+      return {
+        user: user.user,
+        aiCredits,
+        shareOfTotal: totalAiCredits > 0 ? (aiCredits / totalAiCredits) * 100 : 0,
+      };
+    })
+    .filter((user) => user.aiCredits > 0)
+    .sort((a, b) => b.aiCredits - a.aiCredits);
+}
+
+function summarizeTopUsers(
+  concentration: string,
+  rankedUsers: RankedAicUser[],
+  requestedUserCount: number
+): AicConcentrationRow {
+  const users = rankedUsers.slice(0, Math.min(requestedUserCount, rankedUsers.length));
+  const aiCredits = users.reduce((sum, user) => sum + user.aiCredits, 0);
+  const shareOfAicCredits = users.reduce((sum, user) => sum + user.shareOfTotal, 0);
+
+  return {
+    concentration,
+    users: users.length,
+    shareOfAicCredits,
+    aiCredits,
+  };
+}
+
+function buildAicConcentrationRows(rankedUsers: RankedAicUser[]): AicConcentrationRow[] {
+  if (rankedUsers.length === 0) {
+    return [];
+  }
+
+  const topTenPercentUserCount = Math.max(1, Math.ceil(rankedUsers.length * 0.1));
+
+  return [
+    summarizeTopUsers('Top user', rankedUsers, 1),
+    summarizeTopUsers('Top 5 users', rankedUsers, 5),
+    summarizeTopUsers('Top 10%', rankedUsers, topTenPercentUserCount),
+  ];
+}
+
 export function AiUsageOverview() {
   const { billingArtifacts } = useAnalysisContext();
+  const rankedUsers = useMemo(
+    () => buildRankedAicUsers(billingArtifacts?.users ?? []),
+    [billingArtifacts?.users]
+  );
+  const concentrationRows = useMemo(
+    () => buildAicConcentrationRows(rankedUsers),
+    [rankedUsers]
+  );
+  const topSpendDriverUsers = useMemo(
+    () => rankedUsers.slice(0, 10),
+    [rankedUsers]
+  );
 
   if (!billingArtifacts?.hasAnyAicData) {
     return (
@@ -25,7 +120,7 @@ export function AiUsageOverview() {
       <div>
         <h2 className="text-2xl font-semibold tracking-tight text-[#1f2328]">AI Usage</h2>
         <p className="text-sm text-[#636c76] mt-1">
-          AI Credits consumption patterns across users, measured in USD gross usage.
+          AI Credits consumption patterns across users, including credit volume and gross usage.
         </p>
       </div>
 
@@ -38,6 +133,116 @@ export function AiUsageOverview() {
         </div>
         <div className="p-5">
           <UsersAicClustersChart users={billingArtifacts.users} />
+        </div>
+      </div>
+
+      <div className="bg-white border border-[#d1d9e0] rounded-md overflow-hidden">
+        <div className="px-5 py-4 border-b border-[#d1d9e0]">
+          <h3 className="text-sm font-medium text-[#1f2328]">AI Credits Concentration</h3>
+          <p className="text-xs text-[#636c76] mt-0.5">
+            Share of consumed AI Credits concentrated among the highest-consuming users
+          </p>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-full" aria-label="AI Credits concentration by top user groups">
+            <thead>
+              <tr className="border-b border-[#d1d9e0]">
+                <th className="px-5 py-3 text-left text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
+                  Concentration
+                </th>
+                <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
+                  Users
+                </th>
+                <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
+                  Share of AI Credits
+                </th>
+                <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
+                  AI Credits
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[#d1d9e0]">
+              {concentrationRows.length > 0 ? (
+                concentrationRows.map((row) => (
+                  <tr key={row.concentration} className="hover:bg-[#fcfdff] transition-colors">
+                    <td className="px-5 py-3 whitespace-nowrap text-sm font-medium text-[#1f2328]">
+                      {row.concentration}
+                    </td>
+                    <td className="px-5 py-3 whitespace-nowrap text-sm font-mono tabular-nums text-[#636c76] text-right">
+                      {row.users.toLocaleString()}
+                    </td>
+                    <td className="px-5 py-3 whitespace-nowrap text-sm font-mono tabular-nums text-[#636c76] text-right">
+                      {formatPercentage(row.shareOfAicCredits)}
+                    </td>
+                    <td className="px-5 py-3 whitespace-nowrap text-sm font-mono tabular-nums font-semibold text-[#1f2328] text-right">
+                      {formatAiCredits(row.aiCredits)}
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={4} className="px-5 py-8 text-center text-sm text-[#636c76]">
+                    No AI Credits consumption is available for the current users
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="bg-white border border-[#d1d9e0] rounded-md overflow-hidden">
+        <div className="px-5 py-4 border-b border-[#d1d9e0]">
+          <h3 className="text-sm font-medium text-[#1f2328]">Top Spend Drivers</h3>
+          <p className="text-xs text-[#636c76] mt-0.5">
+            Top 10 users ranked by AI Credits consumption
+          </p>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-full" aria-label="Users ranked by AI Credits consumption">
+            <thead>
+              <tr className="border-b border-[#d1d9e0]">
+                <th className="w-16 px-4 py-3 text-left text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
+                  Rank
+                </th>
+                <th className="px-5 py-3 text-left text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
+                  Username
+                </th>
+                <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
+                  AI Credits
+                </th>
+                <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
+                  Share
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[#d1d9e0]">
+              {topSpendDriverUsers.length > 0 ? (
+                topSpendDriverUsers.map((user, index) => (
+                  <tr key={user.user} className="hover:bg-[#fcfdff] transition-colors">
+                    <td className="w-16 px-4 py-3 whitespace-nowrap text-sm font-mono tabular-nums text-[#636c76] text-left">
+                      {index + 1}
+                    </td>
+                    <td className="px-5 py-3 whitespace-nowrap text-sm font-medium text-[#1f2328]">
+                      {user.user}
+                    </td>
+                    <td className="px-5 py-3 whitespace-nowrap text-sm font-mono tabular-nums font-semibold text-[#1f2328] text-right">
+                      {formatAiCredits(user.aiCredits)}
+                    </td>
+                    <td className="px-5 py-3 whitespace-nowrap text-sm font-mono tabular-nums text-[#636c76] text-right">
+                      {formatPercentage(user.shareOfTotal)}
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={4} className="px-5 py-8 text-center text-sm text-[#636c76]">
+                    No AI Credits consumption is available for the current users
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
         </div>
       </div>
     </div>

--- a/src/components/AiUsageOverview.tsx
+++ b/src/components/AiUsageOverview.tsx
@@ -2,9 +2,9 @@
 
 import { useMemo } from 'react';
 
-import { PRICING } from '@/constants/pricing';
 import { useAnalysisContext } from '@/context/AnalysisContext';
 import type { BillingUserTotals } from '@/utils/ingestion';
+import { getEffectiveAicQuantity } from '@/utils/aicFields';
 
 import { UsersAicClustersChart } from './charts/UsersAicClustersChart';
 
@@ -29,22 +29,12 @@ function formatAiCredits(value: number): string {
   return value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
-function getConsumedAiCredits(user: BillingUserTotals): number {
-  if (typeof user.aicQuantity === 'number') {
-    return user.aicQuantity;
-  }
-
-  return typeof user.aicGrossAmount === 'number'
-    ? user.aicGrossAmount / PRICING.AI_CREDIT_USD_VALUE
-    : 0;
-}
-
 function buildRankedAicUsers(users: BillingUserTotals[]): RankedAicUser[] {
-  const totalAiCredits = users.reduce((sum, user) => sum + getConsumedAiCredits(user), 0);
+  const totalAiCredits = users.reduce((sum, user) => sum + getEffectiveAicQuantity(user), 0);
 
   return users
     .map((user) => {
-      const aiCredits = getConsumedAiCredits(user);
+      const aiCredits = getEffectiveAicQuantity(user);
 
       return {
         user: user.user,

--- a/src/components/ModelUsageTrendsOverview.tsx
+++ b/src/components/ModelUsageTrendsOverview.tsx
@@ -2,12 +2,12 @@
 
 import React, { useMemo } from 'react';
 
-import { PRICING } from '@/constants/pricing';
 import { useAnalysisContext } from '@/context/AnalysisContext';
 import { ModelDailyStackedChart } from '@/components/charts/ModelDailyStackedChart';
 import type { ModelDailyDatum } from '@/components/charts/ModelDailyStackedChart';
 import type { ProcessedData } from '@/types/csv';
 import { filterDailySeriesByMonths } from '@/utils/analytics/filters';
+import { getEffectiveAicQuantity } from '@/utils/aicFields';
 import { formatCurrency } from '@/utils/formatters';
 import { buildDailyModelUsageFromArtifacts } from '@/utils/ingestion/analytics';
 import { generateModelColors } from '@/utils/modelColors';
@@ -18,12 +18,6 @@ interface TopAicModelRow {
   aicQuantity: number;
   aicGrossAmount: number;
   share: number;
-}
-
-function getEffectiveAicQuantity(aicQuantity: number, aicGrossAmount: number): number {
-  const quantityDerivedFromGross = aicGrossAmount / PRICING.AI_CREDIT_USD_VALUE;
-
-  return Math.max(aicQuantity, quantityDerivedFromGross);
 }
 
 function enumerateDateKeys(start: string, end: string): string[] {
@@ -122,7 +116,7 @@ export function ModelUsageTrendsOverview() {
       .map(([model, totals]) => ({
         model,
         requests: totals.quantity,
-        aicQuantity: getEffectiveAicQuantity(totals.aicQuantity, totals.aicGrossAmount),
+        aicQuantity: getEffectiveAicQuantity(totals),
         aicGrossAmount: totals.aicGrossAmount,
       }))
       .filter((row) => row.aicQuantity > 0 || row.aicGrossAmount > 0);

--- a/src/utils/aicFields.ts
+++ b/src/utils/aicFields.ts
@@ -1,6 +1,17 @@
+import { PRICING } from '@/constants/pricing';
+
 interface AicFields {
   aicQuantity?: number;
   aicGrossAmount?: number;
+}
+
+export function getEffectiveAicQuantity(row: AicFields): number {
+  const quantity = typeof row.aicQuantity === 'number' ? row.aicQuantity : 0;
+  const quantityDerivedFromGross = typeof row.aicGrossAmount === 'number'
+    ? row.aicGrossAmount / PRICING.AI_CREDIT_USD_VALUE
+    : 0;
+
+  return Math.max(quantity, quantityDerivedFromGross);
 }
 
 export function hasAicFields(rows: Iterable<AicFields>): boolean {


### PR DESCRIPTION
AI usage reviewers need a faster way to identify whether credits are concentrated among a few users and which users are driving consumption. This adds focused tables below the AI usage clustering chart so the page surfaces both concentration and top spend drivers without requiring reviewers to inspect the full user list.

The implementation derives ranked users from billing artifacts, uses effective consumed AI Credits as the primary metric, and falls back to the existing AI credit pricing constant when gross AIC amount implies more credits than the explicit quantity. The spend-driver table is intentionally capped at the top 10 users, with a compact left-aligned rank column for readability.

| Commit | Change |
|--------|--------|
| `feat: add AI usage concentration tables` | Adds concentration and top-10 spend-driver tables to the AI Usage overview, including AI Credits totals and share of total consumed credits. |
| `fix: use effective AI credits for rankings` | Uses a shared effective AIC quantity helper so rankings and shares account for the larger of explicit quantity and gross-derived credits. |

Validation:
- `npm run build && npm run lint && npm run test`

Note: lint reports the existing `AdvisorySection.tsx` hook dependency warning, but exits successfully.