### PR TITLE
Update AI Credits spender clusters

### DIFF
--- a/__tests__/components/DataAnalysisBilling.test.tsx
+++ b/__tests__/components/DataAnalysisBilling.test.tsx
@@ -195,7 +195,7 @@ describe('DataAnalysis billing summary', () => {
       expect(screen.getByRole('heading', { name: 'AI Usage' })).toBeInTheDocument();
       expect(screen.getByText('AI Credits User Clusters')).toBeInTheDocument();
       expect(screen.getByRole('table', { name: 'AI Credits user clusters' })).toBeInTheDocument();
-      expect(screen.getByText('Heavy AIC users')).toBeInTheDocument();
+      expect(screen.getByText('Near-zero users')).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Cost Centers' })[0]);

--- a/__tests__/utils/userAicClusters.test.ts
+++ b/__tests__/utils/userAicClusters.test.ts
@@ -1,0 +1,53 @@
+import type { BillingUserTotals } from '@/utils/ingestion';
+import { buildUserAicClusters, NEAR_ZERO_AIC_GROSS_AMOUNT_USD } from '@/utils/analytics/userAicClusters';
+
+function makeBillingUser(user: string, aicGrossAmount: number): BillingUserTotals {
+  return {
+    user,
+    quantity: aicGrossAmount * 10,
+    aicGrossAmount,
+  };
+}
+
+describe('user AI Credits clusters', () => {
+  test('segments spenders by requested percentile bands after near-zero users', () => {
+    const users = [
+      makeBillingUser('test-user-zero', 0),
+      makeBillingUser('test-user-near-zero', NEAR_ZERO_AIC_GROSS_AMOUNT_USD - 0.01),
+      ...Array.from({ length: 20 }, (_, index) => makeBillingUser(`test-user-${index + 1}`, index + 1)),
+    ];
+
+    const clusters = buildUserAicClusters(users);
+    const byName = new Map(clusters.map((cluster) => [cluster.cluster, cluster]));
+
+    expect(clusters.map((cluster) => cluster.cluster)).toEqual([
+      'Power Users',
+      'Heavy Users',
+      'Typical users',
+      'Light users',
+      'Near-zero users',
+    ]);
+    expect(byName.get('Power Users')?.users).toBe(1);
+    expect(byName.get('Power Users')?.minAicGrossAmount).toBe(20);
+    expect(byName.get('Heavy Users')?.users).toBe(3);
+    expect(byName.get('Heavy Users')?.minAicGrossAmount).toBe(17);
+    expect(byName.get('Heavy Users')?.maxAicGrossAmount).toBe(19);
+    expect(byName.get('Typical users')?.users).toBe(11);
+    expect(byName.get('Typical users')?.minAicGrossAmount).toBe(6);
+    expect(byName.get('Typical users')?.maxAicGrossAmount).toBe(16);
+    expect(byName.get('Light users')?.users).toBe(5);
+    expect(byName.get('Light users')?.minAicGrossAmount).toBe(1);
+    expect(byName.get('Light users')?.maxAicGrossAmount).toBe(5);
+    expect(byName.get('Near-zero users')?.users).toBe(2);
+    expect(byName.get('Near-zero users')?.maxAicGrossAmount).toBe(NEAR_ZERO_AIC_GROSS_AMOUNT_USD - 0.01);
+  });
+
+  test('treats one dollar as spend, not near-zero spend', () => {
+    const clusters = buildUserAicClusters([
+      makeBillingUser('test-user-near-zero', NEAR_ZERO_AIC_GROSS_AMOUNT_USD - 0.01),
+      makeBillingUser('test-user-one-dollar', NEAR_ZERO_AIC_GROSS_AMOUNT_USD),
+    ]);
+
+    expect(clusters.map((cluster) => cluster.cluster)).toEqual(['Power Users', 'Near-zero users']);
+  });
+});

--- a/src/components/AiUsageOverview.tsx
+++ b/src/components/AiUsageOverview.tsx
@@ -118,7 +118,7 @@ export function AiUsageOverview() {
         <div className="px-5 py-4 border-b border-[#d1d9e0]">
           <h3 className="text-sm font-medium text-[#1f2328]">AI Credits User Clusters</h3>
           <p className="text-xs text-[#636c76] mt-0.5">
-            Typical user groups by AI Credits gross consumption in USD
+            User groups by AI Credits gross spend, including near-zero users under $1
           </p>
         </div>
         <div className="p-5">

--- a/src/components/charts/UsersAicClustersChart.tsx
+++ b/src/components/charts/UsersAicClustersChart.tsx
@@ -15,6 +15,8 @@ import {
 } from 'recharts';
 
 import type { BillingUserTotals } from '@/utils/ingestion';
+import { buildUserAicClusters } from '@/utils/analytics/userAicClusters';
+import type { UserAicClusterKey } from '@/utils/analytics/userAicClusters';
 import { formatCurrency } from '@/utils/formatters';
 
 import { chartTooltipContentStyle, chartTooltipLabelStyle } from './chartTooltipStyles';
@@ -23,109 +25,18 @@ interface UsersAicClustersChartProps {
   users: BillingUserTotals[];
 }
 
-interface UserAicPoint {
-  user: string;
-  totalRequests: number;
-  aicGrossAmount: number;
-}
-
-interface UserAicCluster {
-  cluster: string;
-  users: number;
-  averageRequests: number;
-  averageAicGrossAmount: number;
-  totalRequests: number;
-  totalAicGrossAmount: number;
-  minAicGrossAmount: number;
-  maxAicGrossAmount: number;
-  shareOfAicGrossAmount: number;
+interface ClusterStyle {
   fill: string;
   dotClassName: string;
 }
 
-const CLUSTER_COLORS = ['#8c959f', '#60a5fa', '#6366f1', '#8b5cf6'];
-const CLUSTER_DOT_CLASSES = ['bg-[#8c959f]', 'bg-[#60a5fa]', 'bg-indigo-500', 'bg-[#8b5cf6]'];
-
-function summarizeCluster(
-  cluster: string,
-  points: UserAicPoint[],
-  totalAicGrossAmount: number,
-  fill: string,
-  dotClassName: string
-): UserAicCluster {
-  const totalRequests = points.reduce((sum, point) => sum + point.totalRequests, 0);
-  const clusterAicGrossAmount = points.reduce((sum, point) => sum + point.aicGrossAmount, 0);
-  const sortedSpend = points.map((point) => point.aicGrossAmount).sort((a, b) => a - b);
-
-  return {
-    cluster,
-    users: points.length,
-    averageRequests: totalRequests / points.length,
-    averageAicGrossAmount: clusterAicGrossAmount / points.length,
-    totalRequests,
-    totalAicGrossAmount: clusterAicGrossAmount,
-    minAicGrossAmount: sortedSpend[0] ?? 0,
-    maxAicGrossAmount: sortedSpend[sortedSpend.length - 1] ?? 0,
-    shareOfAicGrossAmount: totalAicGrossAmount > 0 ? (clusterAicGrossAmount / totalAicGrossAmount) * 100 : 0,
-    fill,
-    dotClassName,
-  };
-}
-
-function buildUserAicClusters(users: BillingUserTotals[]): UserAicCluster[] {
-  const points = users.map((user) => ({
-    user: user.user,
-    totalRequests: user.quantity,
-    aicGrossAmount: user.aicGrossAmount ?? 0,
-  }));
-
-  const totalAicGrossAmount = points.reduce((sum, point) => sum + point.aicGrossAmount, 0);
-  const noSpendUsers = points.filter((point) => point.aicGrossAmount <= 0);
-  const spendingUsers = points
-    .filter((point) => point.aicGrossAmount > 0)
-    .sort((a, b) => a.aicGrossAmount - b.aicGrossAmount);
-
-  const clusters: UserAicCluster[] = [];
-
-  if (noSpendUsers.length > 0) {
-    clusters.push(summarizeCluster(
-      'No AIC spend',
-      noSpendUsers,
-      totalAicGrossAmount,
-      CLUSTER_COLORS[0],
-      CLUSTER_DOT_CLASSES[0]
-    ));
-  }
-
-  const bucketCount = Math.min(3, spendingUsers.length);
-  if (bucketCount === 0) {
-    return clusters;
-  }
-
-  const bucketNames = bucketCount === 1
-    ? ['AIC users']
-    : bucketCount === 2
-      ? ['Light AIC users', 'Heavy AIC users']
-      : ['Light AIC users', 'Typical AIC users', 'Heavy AIC users'];
-
-  for (let bucketIndex = 0; bucketIndex < bucketCount; bucketIndex += 1) {
-    const start = Math.floor((bucketIndex * spendingUsers.length) / bucketCount);
-    const end = Math.floor(((bucketIndex + 1) * spendingUsers.length) / bucketCount);
-    const bucketUsers = spendingUsers.slice(start, end);
-
-    if (bucketUsers.length > 0) {
-      clusters.push(summarizeCluster(
-        bucketNames[bucketIndex],
-        bucketUsers,
-        totalAicGrossAmount,
-        CLUSTER_COLORS[Math.min(bucketIndex + 1, CLUSTER_COLORS.length - 1)],
-        CLUSTER_DOT_CLASSES[Math.min(bucketIndex + 1, CLUSTER_DOT_CLASSES.length - 1)]
-      ));
-    }
-  }
-
-  return clusters;
-}
+const CLUSTER_STYLES: Record<UserAicClusterKey, ClusterStyle> = {
+  power: { fill: '#8b5cf6', dotClassName: 'bg-[#8b5cf6]' },
+  heavy: { fill: '#6366f1', dotClassName: 'bg-indigo-500' },
+  typical: { fill: '#60a5fa', dotClassName: 'bg-[#60a5fa]' },
+  light: { fill: '#8c959f', dotClassName: 'bg-[#8c959f]' },
+  nearZero: { fill: '#d1d9e0', dotClassName: 'bg-[#d1d9e0]' },
+};
 
 export function UsersAicClustersChart({ users }: UsersAicClustersChartProps) {
   const clusters = useMemo(() => buildUserAicClusters(users), [users]);
@@ -183,7 +94,7 @@ export function UsersAicClustersChart({ users }: UsersAicClustersChartProps) {
             />
             <Scatter name="User clusters" data={clusters} fill="#6366f1">
               {clusters.map((cluster) => (
-                <Cell key={cluster.cluster} fill={cluster.fill} />
+                <Cell key={cluster.cluster} fill={CLUSTER_STYLES[cluster.key].fill} />
               ))}
               <LabelList dataKey="cluster" position="top" fill="#1f2328" fontSize={12} />
             </Scatter>
@@ -221,7 +132,7 @@ export function UsersAicClustersChart({ users }: UsersAicClustersChartProps) {
                 <td className="px-5 py-3 whitespace-nowrap text-sm font-medium text-[#1f2328]">
                   <span className="inline-flex items-center gap-2">
                     <span
-                      className={`w-2.5 h-2.5 rounded-full ${cluster.dotClassName}`}
+                      className={`w-2.5 h-2.5 rounded-full ${CLUSTER_STYLES[cluster.key].dotClassName}`}
                       aria-hidden="true"
                     />
                     {cluster.cluster}

--- a/src/utils/analytics/index.ts
+++ b/src/utils/analytics/index.ts
@@ -2,4 +2,5 @@
 export * from './quota';
 export * from './insights';
 export * from './advisory';
+export * from './userAicClusters';
 export * from './types';

--- a/src/utils/analytics/userAicClusters.ts
+++ b/src/utils/analytics/userAicClusters.ts
@@ -34,9 +34,24 @@ function summarizeCluster(
   points: UserAicPoint[],
   totalAicGrossAmount: number
 ): UserAicCluster {
-  const totalRequests = points.reduce((sum, point) => sum + point.totalRequests, 0);
-  const clusterAicGrossAmount = points.reduce((sum, point) => sum + point.aicGrossAmount, 0);
-  const sortedSpend = points.map((point) => point.aicGrossAmount).sort((a, b) => a - b);
+  let totalRequests = 0;
+  let clusterAicGrossAmount = 0;
+  let minAicGrossAmount = 0;
+  let maxAicGrossAmount = 0;
+
+  points.forEach((point, index) => {
+    totalRequests += point.totalRequests;
+    clusterAicGrossAmount += point.aicGrossAmount;
+
+    if (index === 0) {
+      minAicGrossAmount = point.aicGrossAmount;
+      maxAicGrossAmount = point.aicGrossAmount;
+      return;
+    }
+
+    minAicGrossAmount = Math.min(minAicGrossAmount, point.aicGrossAmount);
+    maxAicGrossAmount = Math.max(maxAicGrossAmount, point.aicGrossAmount);
+  });
 
   return {
     key,
@@ -46,8 +61,8 @@ function summarizeCluster(
     averageAicGrossAmount: clusterAicGrossAmount / points.length,
     totalRequests,
     totalAicGrossAmount: clusterAicGrossAmount,
-    minAicGrossAmount: sortedSpend[0] ?? 0,
-    maxAicGrossAmount: sortedSpend[sortedSpend.length - 1] ?? 0,
+    minAicGrossAmount,
+    maxAicGrossAmount,
     shareOfAicGrossAmount: totalAicGrossAmount > 0 ? (clusterAicGrossAmount / totalAicGrossAmount) * 100 : 0,
   };
 }

--- a/src/utils/analytics/userAicClusters.ts
+++ b/src/utils/analytics/userAicClusters.ts
@@ -1,0 +1,116 @@
+import type { BillingUserTotals } from '@/utils/ingestion';
+
+interface UserAicPoint {
+  totalRequests: number;
+  aicGrossAmount: number;
+}
+
+export type UserAicClusterKey = 'power' | 'heavy' | 'typical' | 'light' | 'nearZero';
+
+export interface UserAicCluster {
+  key: UserAicClusterKey;
+  cluster: string;
+  users: number;
+  averageRequests: number;
+  averageAicGrossAmount: number;
+  totalRequests: number;
+  totalAicGrossAmount: number;
+  minAicGrossAmount: number;
+  maxAicGrossAmount: number;
+  shareOfAicGrossAmount: number;
+}
+
+interface ClusterBucket {
+  key: UserAicClusterKey;
+  label: string;
+  points: UserAicPoint[];
+}
+
+export const NEAR_ZERO_AIC_GROSS_AMOUNT_USD = 1;
+
+function summarizeCluster(
+  key: UserAicClusterKey,
+  cluster: string,
+  points: UserAicPoint[],
+  totalAicGrossAmount: number
+): UserAicCluster {
+  const totalRequests = points.reduce((sum, point) => sum + point.totalRequests, 0);
+  const clusterAicGrossAmount = points.reduce((sum, point) => sum + point.aicGrossAmount, 0);
+  const sortedSpend = points.map((point) => point.aicGrossAmount).sort((a, b) => a - b);
+
+  return {
+    key,
+    cluster,
+    users: points.length,
+    averageRequests: totalRequests / points.length,
+    averageAicGrossAmount: clusterAicGrossAmount / points.length,
+    totalRequests,
+    totalAicGrossAmount: clusterAicGrossAmount,
+    minAicGrossAmount: sortedSpend[0] ?? 0,
+    maxAicGrossAmount: sortedSpend[sortedSpend.length - 1] ?? 0,
+    shareOfAicGrossAmount: totalAicGrossAmount > 0 ? (clusterAicGrossAmount / totalAicGrossAmount) * 100 : 0,
+  };
+}
+
+function buildPercentileBuckets(spendingUsers: UserAicPoint[]): ClusterBucket[] {
+  const spendingUserCount = spendingUsers.length;
+  const powerCount = getBandUserCount(spendingUserCount, spendingUserCount, 0.05);
+  let remainingUserCount = spendingUserCount - powerCount;
+
+  const heavyCount = getBandUserCount(spendingUserCount, remainingUserCount, 0.15);
+  remainingUserCount -= heavyCount;
+
+  const lightCount = getBandUserCount(spendingUserCount, remainingUserCount, 0.25);
+  remainingUserCount -= lightCount;
+
+  const typicalCount = remainingUserCount;
+  let cursor = 0;
+
+  const lightUsers = spendingUsers.slice(cursor, cursor + lightCount);
+  cursor += lightCount;
+
+  const typicalUsers = spendingUsers.slice(cursor, cursor + typicalCount);
+  cursor += typicalCount;
+
+  const heavyUsers = spendingUsers.slice(cursor, cursor + heavyCount);
+  cursor += heavyCount;
+
+  const powerUsers = spendingUsers.slice(cursor, cursor + powerCount);
+
+  return [
+    { key: 'power', label: 'Power Users', points: powerUsers },
+    { key: 'heavy', label: 'Heavy Users', points: heavyUsers },
+    { key: 'typical', label: 'Typical users', points: typicalUsers },
+    { key: 'light', label: 'Light users', points: lightUsers },
+  ];
+}
+
+function getBandUserCount(totalUsers: number, remainingUsers: number, share: number): number {
+  if (remainingUsers === 0) return 0;
+
+  return Math.min(remainingUsers, Math.max(1, Math.round(totalUsers * share)));
+}
+
+export function buildUserAicClusters(users: BillingUserTotals[]): UserAicCluster[] {
+  const points = users.map((user) => ({
+    totalRequests: user.quantity,
+    aicGrossAmount: user.aicGrossAmount ?? 0,
+  }));
+
+  const totalAicGrossAmount = points.reduce((sum, point) => sum + point.aicGrossAmount, 0);
+  const nearZeroUsers = points.filter((point) => point.aicGrossAmount < NEAR_ZERO_AIC_GROSS_AMOUNT_USD);
+  const spendingUsers = points
+    .filter((point) => point.aicGrossAmount >= NEAR_ZERO_AIC_GROSS_AMOUNT_USD)
+    .sort((a, b) => a.aicGrossAmount - b.aicGrossAmount);
+
+  const percentileBuckets = buildPercentileBuckets(spendingUsers);
+  const nearZeroBucket: ClusterBucket = {
+    key: 'nearZero',
+    label: 'Near-zero users',
+    points: nearZeroUsers,
+  };
+
+  return [...percentileBuckets, nearZeroBucket]
+    .filter((bucket) => bucket.points.length > 0)
+    .map((bucket) => summarizeCluster(bucket.key, bucket.label, bucket.points, totalAicGrossAmount));
+}


### PR DESCRIPTION
The existing AI Credits spender distribution split spenders into three equal groups, which hid the top tail and near-zero spenders. This updates clustering to match the requested analysis bands: top 5%, next 15%, middle 55%, lowest 25%, with spend under $1 tracked separately.

## Summary

| Commit | Change |
|--------|--------|
| `feat: update AI Credits spender clusters` | Adds a reusable AI Credits clustering utility, wires the chart to the new category labels and styles, updates the AI Usage copy, and adds direct tests for the percentile bands and <$1 near-zero rule. |

## Validation

- `npm run build`
- `npm run lint`
- `npm run test -- --runInBand`