### PR TITLE
Hide AI Credits card for usage reports

### DIFF
--- a/__tests__/components/DataAnalysisBilling.test.tsx
+++ b/__tests__/components/DataAnalysisBilling.test.tsx
@@ -444,6 +444,9 @@ describe('DataAnalysis billing summary', () => {
       expect(billing).toHaveTextContent('Additional usage');
       expect(billing).not.toHaveTextContent('Discounts');
       expect(billing).not.toHaveTextContent('Net cost');
+      expect(screen.getByText('Current Billing')).toBeInTheDocument();
+      expect(screen.getByText('Licenses')).toBeInTheDocument();
+      expect(screen.queryByLabelText('ai-credits-summary')).not.toBeInTheDocument();
       expect(screen.getByRole('heading', { name: 'AI Credits by Model' })).toBeInTheDocument();
       expect(screen.queryByRole('heading', { name: 'Requests by Model' })).not.toBeInTheDocument();
       expect(screen.getByText('Total: 42.50 AI Credits')).toBeInTheDocument();

--- a/src/components/DataAnalysis.tsx
+++ b/src/components/DataAnalysis.tsx
@@ -243,6 +243,7 @@ function DataAnalysisInner() {
       }
       : null
   );
+  const showAicOverviewCard = aggregatedAic !== null && !isUsageBasedBilling;
 
   const modelRows = useMemo(() => {
     if (usageBasedBillingArtifacts) {
@@ -433,7 +434,7 @@ function DataAnalysisInner() {
             <div className="space-y-6">
               {/* Current Billing + Licenses row */}
               {costMetricsAvailable && aggregatedCosts && (
-                <div className={`grid grid-cols-1 ${aggregatedAic ? 'md:grid-cols-3' : 'md:grid-cols-2'} gap-6 opacity-0 animate-fade-in-up`} style={{ animationDelay: '50ms' }}>
+                <div className={`grid grid-cols-1 ${showAicOverviewCard ? 'md:grid-cols-3' : 'md:grid-cols-2'} gap-6 opacity-0 animate-fade-in-up`} style={{ animationDelay: '50ms' }}>
                   {/* Current Billing */}
                   <div className="bg-white border border-[#d1d9e0] rounded-md p-5">
                     <p className="text-xs font-bold text-[#636c76] uppercase tracking-wider text-center mb-3">Current Billing</p>
@@ -497,7 +498,7 @@ function DataAnalysisInner() {
                     </div>
                   </div>
 
-                  {aggregatedAic && (
+                  {showAicOverviewCard && (
                     <div className="bg-white border border-[#d1d9e0] rounded-md p-5">
                       <p className="text-xs font-bold text-[#636c76] uppercase tracking-wider text-center mb-3">AI Credits</p>
                       <p className="text-3xl font-bold text-[#1f2328] text-center">


### PR DESCRIPTION
Usage-based billing reports already surface AI Credits throughout the overview and model tables, so the separate AI Credits summary card duplicated information and made the top row busier than needed. This keeps the overview focused on Current Billing and Licenses for usage-based reports while preserving the AI Credits card for non-usage reports that include those fields.

| Commit | Change |
|--------|--------|
| `fix: hide AI Credits card for usage reports` | Suppresses the AI Credits overview card when the report uses AI Credits as the billing unit and adds regression coverage for the usage-based overview card set. |

Validation:
- `npm run build && npm run lint && npm run test`