### PR TITLE
Refactor fallback model aggregation

### DIFF
--- a/__tests__/hooks/useAnalyzedData.test.ts
+++ b/__tests__/hooks/useAnalyzedData.test.ts
@@ -1,0 +1,56 @@
+import { renderHook } from '@testing-library/react';
+
+import { useAnalyzedData } from '@/hooks/useAnalyzedData';
+import type { ProcessedData } from '@/types/csv';
+
+function makeProcessedData(
+  model: string,
+  requestsUsed: number,
+  overrides: Partial<ProcessedData> = {}
+): ProcessedData {
+  const dateKey = overrides.dateKey ?? '2026-03-11';
+
+  return {
+    timestamp: new Date(`${dateKey}T00:00:00.000Z`),
+    user: 'test-user-one',
+    model,
+    requestsUsed,
+    exceedsQuota: false,
+    totalQuota: 'Unknown',
+    quotaValue: 'unknown',
+    iso: `${dateKey}T00:00:00.000Z`,
+    dateKey,
+    monthKey: dateKey.slice(0, 7),
+    epoch: new Date(`${dateKey}T00:00:00.000Z`).getTime(),
+    ...overrides,
+  };
+}
+
+describe('useAnalyzedData fallback', () => {
+  test('builds sorted model totals through usage artifacts and includes non-Copilot usage', () => {
+    const baseProcessed = [
+      makeProcessedData('model-one', 2),
+      makeProcessedData('Code Review', 7, {
+        user: '',
+        isNonCopilotUsage: true,
+        usageBucket: 'non_copilot_code_review',
+      }),
+      makeProcessedData('model-two', 5, {
+        user: 'test-user-two',
+      }),
+      makeProcessedData('model-one', 4),
+    ];
+
+    const { result } = renderHook(() => useAnalyzedData({
+      baseProcessed,
+      selectedMonths: [],
+    }));
+
+    expect(result.current.analysis.requestsByModel).toEqual([
+      { model: 'Code Review', totalRequests: 7 },
+      { model: 'model-one', totalRequests: 6 },
+      { model: 'model-two', totalRequests: 5 },
+    ]);
+    expect(result.current.analysis.totalUniqueUsers).toBe(2);
+  });
+});

--- a/src/hooks/useAnalyzedData.ts
+++ b/src/hooks/useAnalyzedData.ts
@@ -8,6 +8,7 @@ import {
   buildDailyCumulativeDataFromArtifacts,
   analyzeCodingAgentAdoptionFromArtifacts,
   analyzeCodeReviewAdoptionFromArtifacts,
+  buildRequestsByModel,
   buildUsageArtifactsFromProcessedData,
   computeWeeklyQuotaExhaustionFromArtifacts,
   UsageArtifacts,
@@ -66,11 +67,9 @@ export function useAnalyzedData({ baseProcessed, selectedMonths, usageArtifacts,
         const sorted = [...filteredAllRows].sort((a,b)=> a.epoch - b.epoch);
         const timeFrame = { start: sorted[0].dateKey, end: sorted[sorted.length-1].dateKey };
         const uniqueUsers = new Set(userFiltered.map(r=> r.user));
-        const requestsByModelMap = new Map<string, number>();
-        for (const r of filteredAllRows) {
-          requestsByModelMap.set(r.model, (requestsByModelMap.get(r.model) || 0) + r.requestsUsed);
-        }
-        const requestsByModel = Array.from(requestsByModelMap.entries()).map(([model,totalRequests])=>({ model, totalRequests })).sort((a,b)=> b.totalRequests - a.totalRequests);
+        const requestsByModel = buildRequestsByModel(
+          buildUsageArtifactsFromProcessedData(filteredAllRows)
+        );
         return { timeFrame, totalUniqueUsers: uniqueUsers.size, usersExceedingQuota: 0, requestsByModel, quotaBreakdown: buildQuotaBreakdown(userFiltered) };
       })();
       return {


### PR DESCRIPTION
## Summary

Reuse the centralized usage artifact and `buildRequestsByModel` path in the legacy fallback instead of maintaining a second aggregation implementation. Preserve non-Copilot synthetic usage and descending request sort order with a focused hook regression test.

| Commit | Change |
|--------|--------|
| `refactor: reuse model aggregation builders` | Route fallback model totals through the existing artifact/builder chain and cover exact behavior |

## Validation

- `npm run build`
- `npm run lint`
- `npm run test -- --runInBand`

Closes #201