### PR TITLE
refactor: remove redundant processed data wrappers

### DIFF
--- a/__tests__/helpers/processCSVData.ts
+++ b/__tests__/helpers/processCSVData.ts
@@ -1,1 +1,2 @@
-export { analyzeData, processCSVData } from '@/utils/analytics/transformations';
+export { analyzeData } from '@/utils/analytics/transformations';
+export { buildProcessedDataFromRawRows as processCSVData } from '@/utils/ingestion';

--- a/__tests__/utils/newFormatParsing.test.ts
+++ b/__tests__/utils/newFormatParsing.test.ts
@@ -1,5 +1,4 @@
-import { buildProcessedDataLegacy } from '@/utils/ingestion/adapter';
-import { buildProcessedDataFromRows } from '@/utils/ingestion/adapters';
+import { buildProcessedDataFromRawRows, buildProcessedDataFromRows } from '@/utils/ingestion';
 import { normalizeRow } from '@/utils/ingestion/normalizeRow';
 import type { CSVData } from '@/types/csv';
 import type { NormalizedRow } from '@/utils/ingestion/types';
@@ -301,7 +300,7 @@ describe('processCSVData (CSV format)', () => {
     expect(warnings).toEqual([]);
     expect(rows[0].username).toBe(' test-user-one ');
     expect(processCSVData(rows)).toEqual(canonical);
-    expect(buildProcessedDataLegacy(rows)).toEqual(canonical);
+    expect(buildProcessedDataFromRawRows(rows)).toEqual(canonical);
     expect(canonical[0].user).toBe('test-user-one');
     expect(canonical[0]).toMatchObject({
       user: 'test-user-one',

--- a/src/utils/analytics/transformations.ts
+++ b/src/utils/analytics/transformations.ts
@@ -1,16 +1,9 @@
-import { CSVData, ProcessedData, AnalysisResults } from '@/types/csv';
-
-import { buildProcessedDataFromRawRows } from '../ingestion/adapters';
+import { ProcessedData, AnalysisResults } from '@/types/csv';
 
 import { buildQuotaBreakdown, buildUserQuotaMapFromRows, isLegacyPremiumRequestQuotaValue } from './quota';
 
 // Re-export for backwards compatibility
 export type { UserSummary } from './types';
-
-// Convert raw CSV rows into strongly typed processed data (UTC-sensitive: timestamps used as-is)
-export function processCSVData(rawData: CSVData[]): ProcessedData[] {
-  return buildProcessedDataFromRawRows(rawData);
-}
 
 export function analyzeData(data: ProcessedData[]): AnalysisResults {
   if (data.length === 0) {

--- a/src/utils/ingestion/adapter.ts
+++ b/src/utils/ingestion/adapter.ts
@@ -1,21 +1,4 @@
-/**
- * Bridge adapter for backward compatibility.
- * Converts new aggregator outputs back to legacy ProcessedData[] format
- * while components are being migrated.
- */
-
-import { CSVData, ProcessedData } from '@/types/csv';
-
-import { buildProcessedDataFromRawRows } from './adapters';
 import { QuotaArtifacts, UsageArtifacts } from './types';
-
-/**
- * Temporary: reconstruct ProcessedData[] from raw CSV for components
- * that haven't been migrated to use aggregator outputs directly.
- */
-export function buildProcessedDataLegacy(rawData: CSVData[]): ProcessedData[] {
-  return buildProcessedDataFromRawRows(rawData);
-}
 
 /**
  * Enriches UserAggregate[] with quota values from QuotaArtifacts.


### PR DESCRIPTION
## Summary

Remove duplicate production entry points for converting raw billing rows into processed data and migrate tests to the canonical ingestion surface. The test helper retains the useful `processCSVData` name as a test-only alias. UTC-sensitive conversion remains unchanged in `buildProcessedDataFromRawRows`.

| Commit | Change |
|--------|--------|
| `refactor: remove redundant processed data wrappers` | Remove `processCSVData` and `buildProcessedDataLegacy`, then route tests through the canonical ingestion export |

## Validation

- `npm test -- --runInBand __tests__/utils/newFormatParsing.test.ts __tests__/utils/utcDateHandling.test.ts __tests__/utils/billingPeriods.test.ts __tests__/utils/mixedQuotas.test.ts __tests__/utils/dataAnalysis.test.ts`
- `npm run build`
- `npm run lint` (passes with one existing warning in `AdvisorySection.tsx`)
- `npm run test`

Closes #205