### PR TITLE
Reuse UTC date enumeration in user details

### DIFF
--- a/__tests__/components/UserDetailsView.test.tsx
+++ b/__tests__/components/UserDetailsView.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 
 import { UserDetailsView } from '@/components/UserDetailsView';
 import { PRICING } from '@/constants/pricing';
-import type { ProcessedData } from '@/types/csv';
+import type { ProcessedData, UserDailyData } from '@/types/csv';
 
 jest.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div data-testid="chart-container">{children}</div>,
@@ -317,5 +317,46 @@ describe('UserDetailsView', () => {
       'data-y',
       PRICING.BUSINESS_AI_CREDIT_QUOTA.toString()
     );
+  });
+
+  it('enumerates the full UTC date range inclusively in fallback chart data', () => {
+    const createRow = (iso: string, user: string, requestsUsed: number): ProcessedData => {
+      const timestamp = new Date(iso);
+      return {
+        timestamp,
+        user,
+        model: 'test-model-one',
+        requestsUsed,
+        exceedsQuota: false,
+        totalQuota: PRICING.BUSINESS_QUOTA.toString(),
+        quotaValue: PRICING.BUSINESS_QUOTA,
+        iso,
+        dateKey: iso.slice(0, 10),
+        monthKey: iso.slice(0, 7),
+        epoch: timestamp.getTime(),
+      } as ProcessedData;
+    };
+    const processedData = [
+      createRow('2025-06-30T23:59:59Z', 'test-user-one', 2),
+      createRow('2025-07-02T00:00:00Z', 'test-user-two', 1),
+    ];
+
+    render(
+      <UserDetailsView
+        user="test-user-one"
+        processedData={processedData}
+        userQuotaValue={PRICING.BUSINESS_QUOTA}
+        onBack={mockOnBack}
+      />
+    );
+
+    const chartData = JSON.parse(
+      screen.getByTestId('composed-chart').getAttribute('data-chart') ?? '[]'
+    ) as UserDailyData[];
+    expect(chartData).toEqual([
+      { date: '2025-06-30', totalCumulative: 2, 'test-model-one': 2 },
+      { date: '2025-07-01', totalCumulative: 2, 'test-model-one': 0 },
+      { date: '2025-07-02', totalCumulative: 2, 'test-model-one': 0 },
+    ]);
   });
 });

--- a/src/components/UserDetailsView.tsx
+++ b/src/components/UserDetailsView.tsx
@@ -21,6 +21,7 @@ import { hasAicFields } from '@/utils/aicFields';
 import { generateModelColors } from '@/utils/modelColors';
 import { calculateEnterpriseUpgradeSavings } from '@/utils/analytics/costOptimization';
 import { getBillingCostLabels } from '@/utils/billingLabels';
+import { enumerateDatesInclusive } from '@/utils/dateKeys';
 import { formatCurrency } from '@/utils/formatters';
 import { aggregateProductCosts } from '@/utils/productCosts';
 import {
@@ -166,9 +167,10 @@ export function UserDetailsView({
 
     let cumulative = 0;
     const result: UserDailyData[] = [];
+    const startDate = new Date(start).toISOString().slice(0, 10);
+    const endDate = new Date(end).toISOString().slice(0, 10);
 
-    for (let current = new Date(start); current.getTime() <= end; current.setUTCDate(current.getUTCDate() + 1)) {
-      const dateStr = current.toISOString().slice(0, 10);
+    for (const dateStr of enumerateDatesInclusive(startDate, endDate)) {
       const day = byDate.get(dateStr) || [];
       const row: UserDailyData = { date: dateStr, totalCumulative: 0 } as UserDailyData;
       let dailyTotal = 0;


### PR DESCRIPTION
## Summary

| Commit | Change |
|--------|--------|
| `refactor: reuse UTC date enumeration helper` | Replaces the component-local Date loop with the shared UTC-safe inclusive helper and adds a boundary regression test. |

## Validation

- `npm run build`
- `npm run lint`
- `npm run test`

Closes #204