### PR TITLE
refactor: centralize decimal quantity formatting

### DIFF
--- a/__tests__/utils/formatters.test.ts
+++ b/__tests__/utils/formatters.test.ts
@@ -1,4 +1,14 @@
-import { formatCurrency } from '@/utils/formatters';
+import { formatCurrency, formatDecimalQuantity } from '@/utils/formatters';
+
+describe('formatDecimalQuantity', () => {
+  it('formats quantities with locale separators and exactly two decimal places', () => {
+    expect(formatDecimalQuantity(1234.5)).toBe('1,234.50');
+    expect(formatDecimalQuantity(0)).toBe('0.00');
+    expect(formatDecimalQuantity(1000000.123)).toBe('1,000,000.12');
+    expect(formatDecimalQuantity(0.001)).toBe('0.00');
+    expect(formatDecimalQuantity(-100.99)).toBe('-100.99');
+  });
+});
 
 describe('formatCurrency', () => {
   it('formats dollar amounts with thousands separators and two decimal places', () => {

--- a/src/components/BillingGroupTable.tsx
+++ b/src/components/BillingGroupTable.tsx
@@ -4,7 +4,7 @@ import React, { useMemo, useState } from 'react';
 
 import type { ProcessedData } from '@/types/csv';
 import type { BillingGroupTotals } from '@/utils/ingestion';
-import { formatCurrency } from '@/utils/formatters';
+import { formatCurrency, formatDecimalQuantity } from '@/utils/formatters';
 import {
   accumulateProductCost,
   createEmptyProductCostMap,
@@ -114,10 +114,6 @@ interface BillingGroupTableProps<T extends BillingGroupRow> {
   extraColumns?: Array<BillingGroupExtraColumn<T>>;
 }
 
-function formatQuantity(value: number): string {
-  return value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-}
-
 export function BillingGroupTable<T extends BillingGroupRow>({
   title,
   singularLabel,
@@ -200,7 +196,7 @@ export function BillingGroupTable<T extends BillingGroupRow>({
                         </td>
                       ))}
                       <td className="px-6 py-3.5 text-sm text-[#636c76] text-right font-mono">
-                        {formatQuantity(row.requests)}
+                        {formatDecimalQuantity(row.requests)}
                       </td>
                       {hasAicGross && (
                         <td className="px-6 py-3.5 text-sm text-[#636c76] text-right font-mono">
@@ -247,7 +243,7 @@ export function BillingGroupTable<T extends BillingGroupRow>({
                                   <tr key={product.label}>
                                     <td className="px-10 py-2.5 text-sm text-[#636c76]">{product.label}</td>
                                     <td className="px-6 py-2.5 text-sm text-[#636c76] text-right font-mono">
-                                      {formatQuantity(product.requests)}
+                                      {formatDecimalQuantity(product.requests)}
                                     </td>
                                     {hasAicGross && (
                                       <td className="px-6 py-2.5 text-sm text-[#636c76] text-right font-mono">

--- a/src/components/charts/AgentUsersTable.tsx
+++ b/src/components/charts/AgentUsersTable.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 
 import type { BillingCostLabels } from '@/utils/billingLabels';
-import { formatCurrency } from '@/utils/formatters';
+import { formatCurrency, formatDecimalQuantity } from '@/utils/formatters';
 
 export interface AgentUsageTableRow {
   user: string;
@@ -17,7 +17,7 @@ export interface AgentUsageTableRow {
 
 export function formatUsageQuantity(value: number, isUsageBasedBilling: boolean): string {
   if (isUsageBasedBilling) {
-    return value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    return formatDecimalQuantity(value);
   }
 
   return value.toFixed(1);

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,3 +1,7 @@
+export function formatDecimalQuantity(value: number): string {
+  return value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
 export function formatCurrency(value: number): string {
-  return `$${value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  return `$${formatDecimalQuantity(value)}`;
 }


### PR DESCRIPTION
## Summary

| Commit | Change |
|--------|--------|
| `refactor: centralize decimal quantity formatting` | Add one exact two-decimal locale formatter, delegate currency formatting to it, and reuse it in billing quantity tables without changing non-usage formatting. |

## Validation

- `npm test -- --runInBand __tests__/utils/formatters.test.ts __tests__/components/BillingGroupTable.test.tsx __tests__/components/AgentUsersTable.test.tsx`
- `npm run build`
- `npm run lint` (passes with one pre-existing warning in `AdvisorySection.tsx`)
- `npm run test`

Closes #206
