### PR TITLE
test: consolidate daily bucket artifact fixtures

### DIFF
--- a/__tests__/components/CodingAgentOverview.test.tsx
+++ b/__tests__/components/CodingAgentOverview.test.tsx
@@ -6,11 +6,12 @@ import { PRICING } from '@/constants/pricing';
 import type { CodeReviewAnalysis, CodingAgentUser, ProcessedData } from '@/types/csv';
 import type {
   BillingArtifacts,
-  DailyBucketsArtifacts,
   FeatureUsageArtifacts,
   QuotaArtifacts,
   UsageArtifacts,
 } from '@/utils/ingestion';
+
+import { makeDailyBucketsArtifacts } from '../helpers/makeArtifacts';
 
 function buildProcessedRow(partial: Partial<ProcessedData>): ProcessedData {
   const timestamp = new Date('2026-03-01T00:00:00Z');
@@ -61,11 +62,9 @@ function createContextValue() {
       userCount: 0,
       modelCount: 0,
     } as UsageArtifacts,
-    dailyBucketsArtifacts: {
-      dailyUserTotals: new Map(),
-      dailyUserModelTotals: new Map(),
+    dailyBucketsArtifacts: makeDailyBucketsArtifacts([], {
       dateRange: { min: '2025-06-01', max: '2025-06-02' },
-    } as DailyBucketsArtifacts,
+    }),
     featureUsageArtifacts: {
       featureTotals: { codeReview: 0, codingAgent: 0, spark: 0 },
       featureUsers: { codeReview: new Set(), codingAgent: new Set(), spark: new Set() },
@@ -251,11 +250,10 @@ describe('CodingAgentOverview', () => {
         value={{
           ...createContextValue(),
           aggregateProcessedData,
-          dailyBucketsArtifacts: {
-            dailyUserTotals: new Map(),
+          dailyBucketsArtifacts: makeDailyBucketsArtifacts([], {
             dailyUserAicModelTotals,
             dateRange: { min: '2026-03-01', max: '2026-03-01' },
-          } as DailyBucketsArtifacts,
+          }),
         }}
       >
         <CodingAgentOverview

--- a/__tests__/components/MissingRawDataAggregator.test.tsx
+++ b/__tests__/components/MissingRawDataAggregator.test.tsx
@@ -3,6 +3,8 @@ import { render, screen } from '@testing-library/react';
 import { DataAnalysis } from '@/components/DataAnalysis';
 import type { IngestionResult } from '@/utils/ingestion';
 
+import { makeDailyBucketsArtifacts } from '../helpers/makeArtifacts';
+
 // Ensure ResponsiveContainer does not throw in test environment
 beforeAll(() => {
   // Typed minimal ResizeObserver stub for JSDOM test environment (no layout measurements required).
@@ -20,7 +22,7 @@ function createIngestionResultWithoutRawData(): IngestionResult {
     outputs: {
       quota: { quotaByUser: new Map(), conflicts: new Map(), distinctQuotas: new Set(), hasMixedQuotas: false, hasMixedLicenses: false },
       usage: { users: [], modelTotals: {}, userCount: 0, modelCount: 0 },
-      dailyBuckets: { dailyUserTotals: new Map(), dateRange: null, months: [] },
+      dailyBuckets: makeDailyBucketsArtifacts(),
       featureUsage: {
         featureTotals: { codeReview: 0, codingAgent: 0, spark: 0 },
         featureUsers: { codeReview: new Set(), codingAgent: new Set(), spark: new Set() },
@@ -39,7 +41,7 @@ function createIngestionResultWithoutFeatureUsage(): IngestionResult {
     outputs: {
       quota: { quotaByUser: new Map(), conflicts: new Map(), distinctQuotas: new Set(), hasMixedQuotas: false, hasMixedLicenses: false },
       usage: { users: [], modelTotals: {}, userCount: 0, modelCount: 0 },
-      dailyBuckets: { dailyUserTotals: new Map(), dateRange: null, months: [] },
+      dailyBuckets: makeDailyBucketsArtifacts(),
       rawData: []
     },
     rowsProcessed: 0,

--- a/__tests__/helpers/makeArtifacts.test.ts
+++ b/__tests__/helpers/makeArtifacts.test.ts
@@ -1,0 +1,28 @@
+import { makeDailyBucketsArtifacts } from './makeArtifacts';
+
+describe('makeDailyBucketsArtifacts', () => {
+  it('creates a complete empty artifact shape', () => {
+    const artifacts = makeDailyBucketsArtifacts();
+
+    expect(artifacts).toEqual({
+      dailyUserTotals: new Map(),
+      dailyUserAicTotals: new Map(),
+      dailyUserModelTotals: new Map(),
+      dailyUserAicModelTotals: new Map(),
+      dailyBucketTotals: new Map(),
+      dailyBucketModelTotals: new Map(),
+      dateRange: null,
+      months: [],
+    });
+  });
+
+  it('supports explicit UTC date ranges and months for empty fixtures', () => {
+    const artifacts = makeDailyBucketsArtifacts([], {
+      dateRange: { min: '2025-06-30', max: '2025-07-01' },
+      months: ['2025-06', '2025-07'],
+    });
+
+    expect(artifacts.dateRange).toEqual({ min: '2025-06-30', max: '2025-07-01' });
+    expect(artifacts.months).toEqual(['2025-06', '2025-07']);
+  });
+});

--- a/__tests__/helpers/makeArtifacts.ts
+++ b/__tests__/helpers/makeArtifacts.ts
@@ -123,9 +123,14 @@ export interface MakeDailyBucketEntry {
  * Build a {@link DailyBucketsArtifacts} object from flat daily usage entries.
  *
  * Produces daily totals and model totals matching DailyBucketsAggregator output.
+ * Use `overrides` for empty fixtures that need an explicit range, month list, or
+ * intentionally missing optional artifact.
  * Date handling is string-based (UTC-safe) and does not use local timezone conversion.
  */
-export function makeDailyBucketsArtifacts(entries: MakeDailyBucketEntry[]): DailyBucketsArtifacts {
+export function makeDailyBucketsArtifacts(
+  entries: MakeDailyBucketEntry[] = [],
+  overrides: Partial<DailyBucketsArtifacts> = {}
+): DailyBucketsArtifacts {
   const dailyUserTotals = new Map<string, Map<string, number>>();
   const dailyUserAicTotals = new Map<string, Map<string, number>>();
   const dailyUserModelTotals = new Map<string, Map<string, Map<string, number>>>();
@@ -163,7 +168,7 @@ export function makeDailyBucketsArtifacts(entries: MakeDailyBucketEntry[]): Dail
     months.add(e.date.slice(0, 7));
   }
 
-  return {
+  const artifacts: DailyBucketsArtifacts = {
     dailyUserTotals,
     dailyUserAicTotals,
     dailyUserModelTotals,
@@ -173,4 +178,6 @@ export function makeDailyBucketsArtifacts(entries: MakeDailyBucketEntry[]): Dail
     dateRange: min && max ? { min, max } : null,
     months: Array.from(months).sort(),
   };
+
+  return { ...artifacts, ...overrides };
 }

--- a/__tests__/helpers/testUtils.ts
+++ b/__tests__/helpers/testUtils.ts
@@ -2,9 +2,10 @@ import { render, RenderOptions } from '@testing-library/react';
 import { ReactElement } from 'react';
 
 import { PRICING } from '@/constants/pricing';
-import type { DailyBucketsArtifacts } from '@/utils/ingestion';
 import type { CSVData, ProcessedData } from '@/types/csv';
 import { buildDateKeys } from '@/utils/dateKeys';
+
+import { makeDailyBucketsArtifacts } from './makeArtifacts';
 
 // Custom render function with providers if needed
 export const customRender = (
@@ -68,11 +69,11 @@ export const createMockCSVDataArray = (count: number, overrides: Partial<CSVData
   });
 };
 
-export const buildMinimalDailyBucketsArtifact = (processed: ProcessedData[]): DailyBucketsArtifacts => {
+export const buildMinimalDailyBucketsArtifact = (processed: ProcessedData[]) => {
   const monthsSet = new Set<string>();
   for (const row of processed) {
     monthsSet.add(row.monthKey || row.timestamp.toISOString().slice(0, 7));
   }
 
-  return { dailyUserTotals: new Map(), dateRange: null, months: Array.from(monthsSet).sort() };
+  return makeDailyBucketsArtifacts([], { months: Array.from(monthsSet).sort() });
 };

--- a/__tests__/utils/modelDailyUsage.test.ts
+++ b/__tests__/utils/modelDailyUsage.test.ts
@@ -74,12 +74,10 @@ describe('buildDailyModelUsageFromArtifacts', () => {
 
   it('returns empty array when artifacts incomplete', () => {
     const usageArtifacts = makeUsageFromModelTotals({});
-    const dailyBucketsArtifacts = {
+    const dailyBucketsArtifacts = makeDailyBucketsArtifacts([], {
       dateRange: undefined,
-      dailyUserTotals: new Map(),
       dailyUserModelTotals: undefined,
-      months: []
-    } as unknown as DailyBucketsArtifacts;
+    });
 
     const result = buildDailyModelUsageFromArtifacts(dailyBucketsArtifacts, usageArtifacts);
     expect(result).toEqual([]);
@@ -116,13 +114,11 @@ describe('buildDailyModelAicUsageFromArtifacts', () => {
 
   it('returns empty array when AIC model artifacts are missing', () => {
     const usageArtifacts = makeUsageFromModelTotals({ 'test-model-one': 1 });
-    const dailyBucketsArtifacts = {
+    const dailyBucketsArtifacts = makeDailyBucketsArtifacts([], {
       dateRange: { min: '2025-06-01', max: '2025-06-01' },
-      dailyUserTotals: new Map(),
-      dailyUserModelTotals: new Map(),
       dailyUserAicModelTotals: undefined,
       months: ['2025-06'],
-    } as unknown as DailyBucketsArtifacts;
+    });
 
     const result = buildDailyModelAicUsageFromArtifacts(dailyBucketsArtifacts, usageArtifacts);
 


### PR DESCRIPTION
## Summary

- extend `makeDailyBucketsArtifacts` with defaults and typed overrides for empty, date-range, month-aware, and resilience fixtures
- replace sparse inline `DailyBucketsArtifacts` constructions and remove unsafe casts
- delegate `buildMinimalDailyBucketsArtifact` to the full-shape factory
- add focused coverage for complete empty artifacts and UTC date-range/month overrides

| Commit | Change |
|--------|--------|
| `test: consolidate daily bucket artifact fixtures` | Centralize DailyBucketsArtifacts test construction in the full-shape factory |

## Validation

- `npm test -- --runInBand __tests__/helpers/makeArtifacts.test.ts __tests__/components/CodingAgentOverview.test.tsx __tests__/components/MissingRawDataAggregator.test.tsx __tests__/utils/modelDailyUsage.test.ts __tests__/utils/billingPeriods.test.ts __tests__/utils/dataAnalysis.test.ts __tests__/utils/utcDateHandling.test.ts`
- `npm run build`
- `npm run lint`
- `npm run test`

Closes #200