### PR TITLE
Improve user cost center filtering and spend reporting

### DIFF
--- a/__tests__/components/UserDetailsView.test.tsx
+++ b/__tests__/components/UserDetailsView.test.tsx
@@ -137,6 +137,83 @@ describe('UserDetailsView', () => {
     });
   });
 
+  it('groups user spend by cost center and omits the table without cost centers', () => {
+    const makeRow = (
+      date: string,
+      costCenter: string | undefined,
+      requestsUsed: number,
+      grossAmount: number,
+      discountAmount: number,
+      netAmount: number
+    ): ProcessedData => {
+      const timestamp = new Date(`${date}T00:00:00Z`);
+      return {
+        timestamp,
+        user: 'test-user-one',
+        model: 'test-model-one',
+        requestsUsed,
+        exceedsQuota: false,
+        totalQuota: PRICING.BUSINESS_QUOTA.toString(),
+        quotaValue: PRICING.BUSINESS_QUOTA,
+        iso: timestamp.toISOString(),
+        dateKey: date,
+        monthKey: date.slice(0, 7),
+        epoch: timestamp.getTime(),
+        costCenter,
+        grossAmount,
+        discountAmount,
+        netAmount,
+      };
+    };
+    const processedData = [
+      makeRow('2026-03-01', 'test-cost-center-one', 10, 0.4, 0.1, 0.3),
+      makeRow('2026-03-02', 'test-cost-center-one', 5, 0.2, 0.05, 0.15),
+      makeRow('2026-03-03', 'test-cost-center-two', 20, 0.8, 0.2, 0.6),
+      makeRow('2026-03-04', undefined, 2, 0.08, 0, 0.08),
+    ];
+
+    const { rerender } = render(
+      <UserDetailsView
+        user="test-user-one"
+        processedData={processedData}
+        userQuotaValue={PRICING.BUSINESS_QUOTA}
+        onBack={mockOnBack}
+      />
+    );
+
+    const table = screen.getByRole('table', { name: 'Cost per Cost Center' });
+    const firstCostCenterRow = within(table).getByText('test-cost-center-one').closest('tr');
+    const secondCostCenterRow = within(table).getByText('test-cost-center-two').closest('tr');
+
+    expect(firstCostCenterRow).not.toBeNull();
+    expect(firstCostCenterRow).toHaveTextContent('15.00');
+    expect(firstCostCenterRow).toHaveTextContent('$0.60');
+    expect(firstCostCenterRow).toHaveTextContent('-$0.15');
+    expect(firstCostCenterRow).toHaveTextContent('$0.45');
+    expect(secondCostCenterRow).not.toBeNull();
+    expect(secondCostCenterRow).toHaveTextContent('20.00');
+    expect(secondCostCenterRow).toHaveTextContent('$0.60');
+    expect(within(table).queryByText('$0.08')).not.toBeInTheDocument();
+
+    const dailyTable = screen.getByRole('table', { name: 'Daily Model Usage Breakdown' });
+    expect(within(dailyTable).getByRole('columnheader', { name: 'Cost Center' })).toBeInTheDocument();
+    expect(within(dailyTable).getAllByText('test-cost-center-one')).toHaveLength(2);
+    expect(within(dailyTable).getByText('test-cost-center-two')).toBeInTheDocument();
+    expect(within(dailyTable).getByText('—')).toBeInTheDocument();
+
+    rerender(
+      <UserDetailsView
+        user="test-user-one"
+        processedData={[makeRow('2026-03-04', undefined, 2, 0.08, 0, 0.08)]}
+        userQuotaValue={PRICING.BUSINESS_QUOTA}
+        onBack={mockOnBack}
+      />
+    );
+
+    expect(screen.queryByRole('table', { name: 'Cost per Cost Center' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Cost Center' })).not.toBeInTheDocument();
+  });
+
   it('renders AI Credits Gross in product and daily model breakdown tables', async () => {
     const firstTimestamp = new Date('2026-03-01T00:00:00Z');
     const secondTimestamp = new Date('2026-03-02T00:00:00Z');

--- a/__tests__/components/UsersOverviewSorting.test.tsx
+++ b/__tests__/components/UsersOverviewSorting.test.tsx
@@ -55,6 +55,7 @@ function makeUsage(users: UserSummary[]): UsageArtifacts {
     }
     if (u.organization) organizations.add(u.organization);
     if (u.costCenter) costCenters.add(u.costCenter);
+    for (const costCenter of u.costCenters ?? []) costCenters.add(costCenter);
   }
 
   return {
@@ -63,7 +64,8 @@ function makeUsage(users: UserSummary[]): UsageArtifacts {
       totalRequests: u.totalRequests,
       modelBreakdown: u.modelBreakdown,
       organization: u.organization,
-      costCenter: u.costCenter
+      costCenter: u.costCenter,
+      costCenters: u.costCenters,
     })),
     modelTotals,
     userCount: users.length,
@@ -370,22 +372,34 @@ describe('UsersOverview - sorting', () => {
 
   it('filters users by organization and cost center when metadata is available', () => {
     const userData: UserSummary[] = [
-      { user: 'Alice', totalRequests: 10, modelBreakdown: { 'gpt-4': 10 }, organization: 'Org A', costCenter: 'Platform' },
-      { user: 'Bob', totalRequests: 20, modelBreakdown: { 'gpt-4': 20 }, organization: 'Org B', costCenter: 'Security' },
-      { user: 'Charlie', totalRequests: 15, modelBreakdown: { 'gpt-4': 15 }, organization: 'Org A', costCenter: 'Security' },
+      {
+        user: 'test-user-one',
+        totalRequests: 10,
+        modelBreakdown: { 'model-one': 10 },
+        organization: 'test-org-one',
+        costCenter: 'test-cost-center-one',
+        costCenters: ['test-cost-center-one', 'test-cost-center-two'],
+      },
+      { user: 'test-user-two', totalRequests: 20, modelBreakdown: { 'model-one': 20 }, organization: 'test-org-two', costCenter: 'test-cost-center-two' },
+      { user: 'test-user-three', totalRequests: 15, modelBreakdown: { 'model-one': 15 }, organization: 'test-org-one', costCenter: 'test-cost-center-two' },
     ];
 
     const quotaArtifacts = makeQuota([
-      { user: 'Alice', quota: PRICING.BUSINESS_QUOTA },
-      { user: 'Bob', quota: PRICING.BUSINESS_QUOTA },
-      { user: 'Charlie', quota: PRICING.BUSINESS_QUOTA },
+      { user: 'test-user-one', quota: PRICING.BUSINESS_QUOTA },
+      { user: 'test-user-two', quota: PRICING.BUSINESS_QUOTA },
+      { user: 'test-user-three', quota: PRICING.BUSINESS_QUOTA },
     ]);
 
     render(
       <UsersOverview
         userData={userData}
         processedData={[]}
-        dailyCumulativeData={[{ date: '2025-01-01T00:00:00Z', Alice: 1, Bob: 1, Charlie: 1 }]}
+        dailyCumulativeData={[{
+          date: '2025-01-01T00:00:00Z',
+          'test-user-one': 1,
+          'test-user-two': 1,
+          'test-user-three': 1,
+        }]}
         quotaArtifacts={quotaArtifacts}
         usageArtifacts={makeUsage(userData)}
       />
@@ -397,11 +411,14 @@ describe('UsersOverview - sorting', () => {
       return rows.map(row => within(row).getByRole('button').textContent ?? '');
     };
 
-    fireEvent.change(screen.getByLabelText('Organization'), { target: { value: 'Org A' } });
-    expect(getRowUserOrder()).toEqual(['Charlie', 'Alice']);
+    fireEvent.change(screen.getByLabelText('Organization'), { target: { value: 'test-org-one' } });
+    expect(getRowUserOrder()).toEqual(['test-user-three', 'test-user-one']);
 
-    fireEvent.change(screen.getByLabelText('Cost center'), { target: { value: 'Security' } });
-    expect(getRowUserOrder()).toEqual(['Charlie']);
+    fireEvent.change(screen.getByLabelText('Cost center'), { target: { value: 'test-cost-center-one' } });
+    expect(getRowUserOrder()).toEqual(['test-user-one']);
+
+    fireEvent.change(screen.getByLabelText('Cost center'), { target: { value: 'test-cost-center-two' } });
+    expect(getRowUserOrder()).toEqual(['test-user-three', 'test-user-one']);
   });
 
   it('opens inline user details and returns via breadcrumb', () => {

--- a/__tests__/utils/usageAggregator.test.ts
+++ b/__tests__/utils/usageAggregator.test.ts
@@ -21,7 +21,7 @@ describe('UsageAggregator', () => {
 
     const rows: NormalizedRow[] = [
       makeNormalizedRow({ user: 'test-user-one', organization: 'test-org-two', costCenter: 'test-cost-center-one', quantity: 2 }),
-      makeNormalizedRow({ user: 'test-user-one', model: 'gpt-4.1', quantity: 3 }),
+      makeNormalizedRow({ user: 'test-user-one', model: 'gpt-4.1', costCenter: 'test-cost-center-two', quantity: 3 }),
       makeNormalizedRow({ user: 'test-user-two', organization: 'test-org-one', costCenter: 'test-cost-center-two', quantity: 1 }),
       makeNormalizedRow({ user: 'test-user-three', costCenter: 'test-cost-center-two', quantity: 4 }),
     ];
@@ -35,7 +35,13 @@ describe('UsageAggregator', () => {
     expect(output.organizations).toEqual(['test-org-one', 'test-org-two']);
     expect(output.costCenters).toEqual(['test-cost-center-one', 'test-cost-center-two']);
     expect(output.users).toEqual(expect.arrayContaining([
-      expect.objectContaining({ user: 'test-user-one', organization: 'test-org-two', costCenter: 'test-cost-center-one', totalRequests: 5 }),
+      expect.objectContaining({
+        user: 'test-user-one',
+        organization: 'test-org-two',
+        costCenter: 'test-cost-center-one',
+        costCenters: ['test-cost-center-one', 'test-cost-center-two'],
+        totalRequests: 5,
+      }),
       expect.objectContaining({ user: 'test-user-two', organization: 'test-org-one', costCenter: 'test-cost-center-two', totalRequests: 1 }),
       expect.objectContaining({ user: 'test-user-three', organization: undefined, costCenter: 'test-cost-center-two', totalRequests: 4 }),
     ]));

--- a/src/components/UserDetailsView.tsx
+++ b/src/components/UserDetailsView.tsx
@@ -45,6 +45,15 @@ interface TooltipProps {
   valueUnitLabel?: string;
 }
 
+interface UserCostCenterCost {
+  name: string;
+  quantity: number;
+  gross: number;
+  discount: number;
+  net: number;
+  aicGrossAmount: number;
+}
+
 export interface UserDetailsViewProps {
   user: string;
   processedData: ProcessedData[];
@@ -253,6 +262,7 @@ export function UserDetailsView({
   type DailyModelRow = {
     date: string;
     model: string;
+    costCenter?: string;
     requests: number;
     gross: number;
     discount: number;
@@ -275,11 +285,11 @@ export function UserDetailsView({
     );
     if (!hasBillingData) return [];
 
-    // Aggregate by date + model
+    // Aggregate by date + model + cost center so cost-center changes remain visible.
     type Key = string;
-    const agg = new Map<Key, { date: string; model: string; requests: number; gross: number; discount: number; net: number; aicGrossAmount: number }>();
+    const agg = new Map<Key, { date: string; model: string; costCenter?: string; requests: number; gross: number; discount: number; net: number; aicGrossAmount: number }>();
     for (const row of userData) {
-      const key = `${row.dateKey}||${row.model}`;
+      const key = `${row.dateKey}||${row.model}||${row.costCenter ?? ''}`;
       const quantity = isUserUsageBasedBilling ? row.billingQuantity ?? row.requestsUsed : row.requestsUsed;
       const existing = agg.get(key);
       if (existing) {
@@ -292,6 +302,7 @@ export function UserDetailsView({
         agg.set(key, {
           date: row.dateKey,
           model: row.model,
+          costCenter: row.costCenter,
           requests: quantity,
           gross: row.grossAmount ?? 0,
           discount: row.discountAmount ?? 0,
@@ -302,9 +313,11 @@ export function UserDetailsView({
     }
 
     // Sort by date asc, then model
-    const sorted = Array.from(agg.values()).sort((a, b) =>
-      a.date !== b.date ? a.date.localeCompare(b.date) : a.model.localeCompare(b.model)
-    );
+    const sorted = Array.from(agg.values()).sort((a, b) => {
+      if (a.date !== b.date) return a.date.localeCompare(b.date);
+      if (a.model !== b.model) return a.model.localeCompare(b.model);
+      return (a.costCenter ?? '').localeCompare(b.costCenter ?? '');
+    });
 
     // Count rows per date for rowSpan
     const dateSpan = new Map<string, number>();
@@ -328,6 +341,35 @@ export function UserDetailsView({
     );
     if (!hasBillingData) return [];
     return aggregateProductCosts(userData);
+  }, [userData]);
+
+  const costCenterCosts = useMemo((): UserCostCenterCost[] => {
+    const totals = new Map<string, UserCostCenterCost>();
+
+    for (const row of userData) {
+      if (!row.costCenter) {
+        continue;
+      }
+
+      const entry = totals.get(row.costCenter) ?? {
+        name: row.costCenter,
+        quantity: 0,
+        gross: 0,
+        discount: 0,
+        net: 0,
+        aicGrossAmount: 0,
+      };
+      entry.quantity += row.billingQuantity ?? row.requestsUsed;
+      entry.gross += row.grossAmount ?? 0;
+      entry.discount += row.discountAmount ?? 0;
+      entry.net += row.netAmount ?? 0;
+      entry.aicGrossAmount += row.aicGrossAmount ?? 0;
+      totals.set(row.costCenter, entry);
+    }
+
+    return Array.from(totals.values()).sort(
+      (left, right) => right.net - left.net || left.name.localeCompare(right.name)
+    );
   }, [userData]);
 
   const planInfo = {
@@ -437,6 +479,45 @@ export function UserDetailsView({
           })()}
       </div>
 
+      {/* Cost per Cost Center — standalone card */}
+      {costCenterCosts.length > 0 && (
+        <div className="bg-white border border-[#d1d9e0] rounded-md overflow-hidden">
+          <div className="px-5 py-4 border-b border-[#d1d9e0]">
+            <h3 className="text-sm font-medium text-[#1f2328]">Cost per Cost Center</h3>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="min-w-full" aria-label="Cost per Cost Center">
+              <thead>
+                <tr className="border-b border-[#d1d9e0]">
+                  <th className="px-5 py-3 text-left text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">Cost Center</th>
+                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">{userQuantityColumnLabel}</th>
+                  {showAicGross && (
+                    <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">AI Credits Gross</th>
+                  )}
+                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">{userCostLabels.gross}</th>
+                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">{userCostLabels.discount}</th>
+                  <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">{userCostLabels.net}</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[#d1d9e0]">
+                {costCenterCosts.map((costCenter) => (
+                  <tr key={costCenter.name} className="hover:bg-[#fcfdff] transition-colors">
+                    <td className="px-5 py-3 text-sm font-medium text-[#1f2328]">{costCenter.name}</td>
+                    <td className="px-5 py-3 text-sm text-[#636c76] text-right font-mono">{costCenter.quantity.toFixed(2)}</td>
+                    {showAicGross && (
+                      <td className="px-5 py-3 text-sm text-[#636c76] text-right font-mono">{formatCurrency(costCenter.aicGrossAmount)}</td>
+                    )}
+                    <td className="px-5 py-3 text-sm text-[#636c76] text-right font-mono">{formatCurrency(costCenter.gross)}</td>
+                    <td className="px-5 py-3 text-sm text-emerald-600 text-right font-mono">-{formatCurrency(costCenter.discount)}</td>
+                    <td className="px-5 py-3 text-sm font-semibold text-[#1f2328] text-right font-mono">{formatCurrency(costCenter.net)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
       {/* Cost per Product — standalone card */}
       {productCosts.length > 0 && (
         <div className="bg-white border border-[#d1d9e0] rounded-md overflow-hidden">
@@ -531,11 +612,14 @@ export function UserDetailsView({
             <h3 className="text-sm font-medium text-[#1f2328]">Daily Model Usage Breakdown</h3>
           </div>
           <div className="overflow-x-auto">
-            <table className="min-w-full">
+            <table className="min-w-full" aria-label="Daily Model Usage Breakdown">
               <thead>
                 <tr className="border-b border-[#d1d9e0]">
                   <th className="px-5 py-3 w-28 text-left text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa] whitespace-nowrap">Date</th>
                   <th className="px-5 py-3 text-left text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">Model</th>
+                  {costCenterCosts.length > 0 && (
+                    <th className="px-5 py-3 text-left text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa] whitespace-nowrap">Cost Center</th>
+                  )}
                   <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa] whitespace-nowrap">{userQuantityColumnLabel}</th>
                   {showAicGross && (
                     <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa] whitespace-nowrap">AI Credits Gross</th>
@@ -557,6 +641,9 @@ export function UserDetailsView({
                       </td>
                     ) : null}
                     <td className="px-5 py-3 text-sm text-[#636c76]">- {row.model}</td>
+                    {costCenterCosts.length > 0 && (
+                      <td className="px-5 py-3 text-sm text-[#636c76] whitespace-nowrap">{row.costCenter ?? '—'}</td>
+                    )}
                     <td className="px-5 py-3 text-sm font-mono text-[#1f2328] text-right">{row.requests.toFixed(2)}</td>
                     {showAicGross && (
                       <td className="px-5 py-3 text-sm font-mono text-[#636c76] text-right">{formatCurrency(row.aicGrossAmount)}</td>

--- a/src/components/UsersOverview.tsx
+++ b/src/components/UsersOverview.tsx
@@ -122,9 +122,9 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, da
   }, [userData]);
 
   const costCenterOptions = useMemo(() => {
-    const costCenters = userData
-      .map((user) => user.costCenter)
-      .filter((costCenter): costCenter is string => Boolean(costCenter));
+    const costCenters = userData.flatMap((user) => (
+      user.costCenters ?? (user.costCenter ? [user.costCenter] : [])
+    ));
 
     return Array.from(new Set(costCenters)).sort((a, b) => a.localeCompare(b));
   }, [userData]);
@@ -189,7 +189,8 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, da
     userData.filter((user) => {
       const matchesSearch = searchQuery === '' || user.user.toLowerCase().includes(searchQuery.toLowerCase());
       const matchesOrganization = effectiveSelectedOrganization === ALL_FILTERS_VALUE || user.organization === effectiveSelectedOrganization;
-      const matchesCostCenter = effectiveSelectedCostCenter === ALL_FILTERS_VALUE || user.costCenter === effectiveSelectedCostCenter;
+      const userCostCenters = user.costCenters ?? (user.costCenter ? [user.costCenter] : []);
+      const matchesCostCenter = effectiveSelectedCostCenter === ALL_FILTERS_VALUE || userCostCenters.includes(effectiveSelectedCostCenter);
       const matchesPlan = effectiveSelectedPlan === ALL_FILTERS_VALUE || getUserPlanLabel(user.user) === effectiveSelectedPlan;
 
       return matchesSearch && matchesOrganization && matchesCostCenter && matchesPlan;

--- a/src/hooks/useAnalyzedData.ts
+++ b/src/hooks/useAnalyzedData.ts
@@ -102,7 +102,8 @@ export function useAnalyzedData({ baseProcessed, selectedMonths, usageArtifacts,
       totalRequests: u.totalRequests,
       modelBreakdown: u.modelBreakdown,
       organization: u.organization,
-      costCenter: u.costCenter
+      costCenter: u.costCenter,
+      costCenters: u.costCenters,
     })).sort((a, b) => b.totalRequests - a.totalRequests);
     const allModels = Object.keys(usageArtifacts!.modelTotals).sort();
     return {

--- a/src/utils/analytics/types.ts
+++ b/src/utils/analytics/types.ts
@@ -8,4 +8,5 @@ export interface UserSummary {
   modelBreakdown: Record<string, number>;
   organization?: string;
   costCenter?: string;
+  costCenters?: string[];
 }

--- a/src/utils/ingestion/UsageAccumulator.ts
+++ b/src/utils/ingestion/UsageAccumulator.ts
@@ -16,12 +16,18 @@ export interface UsageAccumulationRow {
   usageBucket?: SpecialUsageBucketKey;
 }
 
+interface UserMetadata {
+  organization?: string;
+  costCenter?: string;
+  costCenters: Set<string>;
+}
+
 export class UsageAccumulator {
   private userTotals = new Map<string, number>();
   private userModelTotals = new Map<string, Map<string, number>>();
   private modelTotals = new Map<string, number>();
   private topModelPerUser = new Map<string, { model: string; value: number }>();
-  private userMetadata = new Map<string, { organization?: string; costCenter?: string }>();
+  private userMetadata = new Map<string, UserMetadata>();
   private organizations = new Set<string>();
   private costCenters = new Set<string>();
   private specialBuckets = new Map<SpecialUsageBucketKey, SpecialUsageBucketAggregate>();
@@ -64,12 +70,15 @@ export class UsageAccumulator {
       this.costCenters.add(costCenter);
     }
 
-    const metadata = this.userMetadata.get(user) ?? {};
+    const metadata = this.userMetadata.get(user) ?? { costCenters: new Set<string>() };
     if (!metadata.organization && organization) {
       metadata.organization = organization;
     }
     if (!metadata.costCenter && costCenter) {
       metadata.costCenter = costCenter;
+    }
+    if (costCenter) {
+      metadata.costCenters.add(costCenter);
     }
     this.userMetadata.set(user, metadata);
 
@@ -106,6 +115,9 @@ export class UsageAccumulator {
         topModelValue: topEntry?.value,
         organization: metadata?.organization,
         costCenter: metadata?.costCenter,
+        costCenters: metadata
+          ? Array.from(metadata.costCenters).sort((left, right) => left.localeCompare(right))
+          : [],
       });
     }
 

--- a/src/utils/ingestion/types.ts
+++ b/src/utils/ingestion/types.ts
@@ -149,6 +149,7 @@ export interface UserAggregate {
   quotaValue?: number | 'unknown';
   organization?: string;
   costCenter?: string;
+  costCenters?: string[];
 }
 
 /**


### PR DESCRIPTION
Users who change cost centers during a billing period could not be found reliably because only one assignment was retained. This change preserves all observed cost center associations and adds cost center spend visibility to user details.

## Summary

- Track every cost center observed for each user while preserving the existing primary cost center metadata.
- Match the Users filter against all of a user's cost center associations.
- Add a conditional Cost per Cost Center table with quantity, gross, discount, net, and AI Credits gross totals.
- Add a conditional Cost Center column to the daily model breakdown, splitting rows by date, model, and cost center.
- Keep cost center tables and columns hidden when a user has no cost center data.

## Commits

| Commit | Change |
|--------|--------|
| `feat: improve user cost center reporting` | Fix multi-assignment filtering and add user-level and daily cost center spend reporting |

## Validation

- `npm run build`
- `npm run lint`
- `npm run test`