### PR TITLE
Fix cost center reporting review issues

### DIFF
--- a/__tests__/components/UserDetailsView.test.tsx
+++ b/__tests__/components/UserDetailsView.test.tsx
@@ -214,6 +214,72 @@ describe('UserDetailsView', () => {
     expect(screen.queryByRole('columnheader', { name: 'Cost Center' })).not.toBeInTheDocument();
   });
 
+  it('omits cost center spend when billing fields are unavailable', () => {
+    render(
+      <UserDetailsView
+        user="test-user-one"
+        processedData={createMockProcessedData([PRICING.BUSINESS_QUOTA]).map((row) => ({
+          ...row,
+          user: 'test-user-one',
+          costCenter: 'test-cost-center-one',
+        }))}
+        userQuotaValue={PRICING.BUSINESS_QUOTA}
+        onBack={mockOnBack}
+      />
+    );
+
+    expect(screen.queryByRole('table', { name: 'Cost per Cost Center' })).not.toBeInTheDocument();
+  });
+
+  it('does not count AI Credits as requests in mixed cost center usage', () => {
+    const requestTimestamp = new Date('2026-06-01T00:00:00Z');
+    const creditTimestamp = new Date('2026-06-02T00:00:00Z');
+    const makeRow = (
+      timestamp: Date,
+      usageUnit: 'request' | 'ai_credit',
+      requestsUsed: number,
+      billingQuantity: number
+    ): ProcessedData => ({
+      timestamp,
+      user: 'test-user-one',
+      model: 'test-model-one',
+      requestsUsed,
+      exceedsQuota: false,
+      totalQuota: PRICING.BUSINESS_QUOTA.toString(),
+      quotaValue: PRICING.BUSINESS_QUOTA,
+      iso: timestamp.toISOString(),
+      dateKey: timestamp.toISOString().slice(0, 10),
+      monthKey: timestamp.toISOString().slice(0, 7),
+      epoch: timestamp.getTime(),
+      costCenter: 'test-cost-center-one',
+      usageUnit,
+      billingQuantity,
+      grossAmount: 0.12,
+      discountAmount: 0,
+      netAmount: 0.12,
+    });
+
+    render(
+      <UserDetailsView
+        user="test-user-one"
+        processedData={[
+          makeRow(requestTimestamp, 'request', 3, 3),
+          makeRow(creditTimestamp, 'ai_credit', 0, 42.5),
+        ]}
+        userQuotaValue={PRICING.BUSINESS_QUOTA}
+        onBack={mockOnBack}
+      />
+    );
+
+    const table = screen.getByRole('table', { name: 'Cost per Cost Center' });
+    const costCenterRow = within(table).getByText('test-cost-center-one').closest('tr');
+
+    expect(within(table).getByRole('columnheader', { name: 'Requests' })).toBeInTheDocument();
+    expect(costCenterRow).not.toBeNull();
+    expect(costCenterRow).toHaveTextContent('3.00');
+    expect(costCenterRow).not.toHaveTextContent('45.50');
+  });
+
   it('renders AI Credits Gross in product and daily model breakdown tables', async () => {
     const firstTimestamp = new Date('2026-03-01T00:00:00Z');
     const secondTimestamp = new Date('2026-03-02T00:00:00Z');

--- a/__tests__/hooks/useAnalyzedData.test.ts
+++ b/__tests__/hooks/useAnalyzedData.test.ts
@@ -2,6 +2,9 @@ import { renderHook } from '@testing-library/react';
 
 import { useAnalyzedData } from '@/hooks/useAnalyzedData';
 import type { ProcessedData } from '@/types/csv';
+import { buildUsageArtifactsFromProcessedData } from '@/utils/ingestion';
+
+import { makeDailyBucketsArtifacts, makeQuotaArtifacts } from '../helpers/makeArtifacts';
 
 function makeProcessedData(
   model: string,
@@ -52,5 +55,42 @@ describe('useAnalyzedData fallback', () => {
       { model: 'model-two', totalRequests: 5 },
     ]);
     expect(result.current.analysis.totalUniqueUsers).toBe(2);
+  });
+});
+
+describe('useAnalyzedData artifacts', () => {
+  test('scopes user cost centers to the selected billing period', () => {
+    const baseProcessed = [
+      makeProcessedData('model-one', 2, {
+        costCenter: 'test-cost-center-one',
+      }),
+      makeProcessedData('model-one', 3, {
+        dateKey: '2026-04-11',
+        costCenter: 'test-cost-center-two',
+      }),
+    ];
+    const usageArtifacts = buildUsageArtifactsFromProcessedData(baseProcessed);
+    const quotaArtifacts = makeQuotaArtifacts([{ user: 'test-user-one', quota: 'unknown' }]);
+    const dailyBucketsArtifacts = makeDailyBucketsArtifacts([
+      { date: '2026-03-11', user: 'test-user-one', used: 2 },
+      { date: '2026-04-11', user: 'test-user-one', used: 3 },
+    ]);
+
+    const { result } = renderHook(() => useAnalyzedData({
+      baseProcessed,
+      selectedMonths: ['2026-03'],
+      usageArtifacts,
+      quotaArtifacts,
+      dailyBucketsArtifacts,
+    }));
+
+    expect(result.current.userData).toEqual([
+      expect.objectContaining({
+        user: 'test-user-one',
+        totalRequests: 2,
+        costCenter: 'test-cost-center-one',
+        costCenters: ['test-cost-center-one'],
+      }),
+    ]);
   });
 });

--- a/src/components/UserDetailsView.tsx
+++ b/src/components/UserDetailsView.tsx
@@ -120,6 +120,16 @@ export function UserDetailsView({
   const effectiveUserQuotaValue = artifactUserQuota !== undefined ? artifactUserQuota : userQuotaValue;
 
   const userData = useMemo(() => getUserData(processedData, user), [processedData, user]);
+  const hasBillingData = useMemo(
+    () => userData.some(
+      (row) =>
+        row.grossAmount !== undefined ||
+        row.netAmount !== undefined ||
+        row.discountAmount !== undefined ||
+        row.aicGrossAmount !== undefined
+    ),
+    [userData]
+  );
   const hasUserAiCreditUsage = useMemo(() => userData.some((row) => row.usageUnit === 'ai_credit'), [userData]);
   const hasUserRequestUsage = useMemo(
     () => userData.some((row) => row.usageUnit === 'request' && row.requestsUsed > 0),
@@ -276,13 +286,6 @@ export function UserDetailsView({
   const showAicGross = hasAicGross && !isUserUsageBasedBilling;
 
   const dailyBreakdownRows = useMemo((): DailyModelRow[] => {
-    const hasBillingData = userData.some(
-      (row) =>
-        row.grossAmount !== undefined ||
-        row.netAmount !== undefined ||
-        row.discountAmount !== undefined ||
-        row.aicGrossAmount !== undefined
-    );
     if (!hasBillingData) return [];
 
     // Aggregate by date + model + cost center so cost-center changes remain visible.
@@ -329,21 +332,16 @@ export function UserDetailsView({
       if (isFirst) seenDates.add(r.date);
       return { ...r, isFirstInDate: isFirst, rowSpan: dateSpan.get(r.date) ?? 1 };
     });
-  }, [isUserUsageBasedBilling, userData]);
+  }, [hasBillingData, isUserUsageBasedBilling, userData]);
 
   const productCosts = useMemo(() => {
-    const hasBillingData = userData.some(
-      (row) =>
-        row.grossAmount !== undefined ||
-        row.netAmount !== undefined ||
-        row.discountAmount !== undefined ||
-        row.aicGrossAmount !== undefined
-    );
     if (!hasBillingData) return [];
     return aggregateProductCosts(userData);
-  }, [userData]);
+  }, [hasBillingData, userData]);
 
   const costCenterCosts = useMemo((): UserCostCenterCost[] => {
+    if (!hasBillingData) return [];
+
     const totals = new Map<string, UserCostCenterCost>();
 
     for (const row of userData) {
@@ -359,7 +357,9 @@ export function UserDetailsView({
         net: 0,
         aicGrossAmount: 0,
       };
-      entry.quantity += row.billingQuantity ?? row.requestsUsed;
+      entry.quantity += isUserUsageBasedBilling
+        ? row.aicQuantity ?? row.billingQuantity ?? row.requestsUsed
+        : row.requestsUsed;
       entry.gross += row.grossAmount ?? 0;
       entry.discount += row.discountAmount ?? 0;
       entry.net += row.netAmount ?? 0;
@@ -370,7 +370,7 @@ export function UserDetailsView({
     return Array.from(totals.values()).sort(
       (left, right) => right.net - left.net || left.name.localeCompare(right.name)
     );
-  }, [userData]);
+  }, [hasBillingData, isUserUsageBasedBilling, userData]);
 
   const planInfo = {
     business: { name: 'Copilot Business', monthlyQuota: PRICING.BUSINESS_QUOTA },

--- a/src/hooks/useAnalyzedData.ts
+++ b/src/hooks/useAnalyzedData.ts
@@ -97,7 +97,7 @@ export function useAnalyzedData({ baseProcessed, selectedMonths, usageArtifacts,
     const codingAgentAnalysis = analyzeCodingAgentAdoptionFromArtifacts(effectiveUsage, quotaArtifacts!);
     const codeReviewAnalysis = analyzeCodeReviewAdoptionFromArtifacts(effectiveUsage, quotaArtifacts!);
     const weeklyExhaustion = computeWeeklyQuotaExhaustionFromArtifacts(dailyBucketsArtifacts!, quotaArtifacts!);
-    const userData = usageArtifacts!.users.map(u => ({
+    const userData = effectiveUsage.users.map(u => ({
       user: u.user,
       totalRequests: u.totalRequests,
       modelBreakdown: u.modelBreakdown,


### PR DESCRIPTION
PR #218 was merged before its review comments arrived, leaving billing-period filtering and cost-center spend reporting inconsistent in several edge cases. This follow-up applies all three review findings and adds regression coverage.

## Summary

- Build user summaries from month-filtered usage artifacts so cost-center associations match the selected billing period.
- Suppress cost-center spend when older reports do not include commercial fields.
- Keep mixed request and AI-credit quantities unit-aware so credits are not displayed as requests.

| Commit | Change |
|--------|--------|
| `fix: address cost center review feedback` | Addresses all three post-merge PR #218 review comments and adds regression tests. |

## Validation

- `npm run build`
- `npm run lint` (passes with one pre-existing warning in `AdvisorySection.tsx`)
- `npm run test` (297 passed, 1 skipped)