### PR TITLE
refactor: reuse filtered user metadata aggregate

### DIFF
--- a/__tests__/components/UserDetailsView.test.tsx
+++ b/__tests__/components/UserDetailsView.test.tsx
@@ -2,7 +2,10 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 
 import { UserDetailsView } from '@/components/UserDetailsView';
 import { PRICING } from '@/constants/pricing';
+import { AnalysisContext } from '@/context/AnalysisContext';
 import type { ProcessedData, UserDailyData } from '@/types/csv';
+
+import { makeUsageArtifacts } from '../helpers/makeArtifacts';
 
 jest.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div data-testid="chart-container">{children}</div>,
@@ -123,6 +126,35 @@ describe('UserDetailsView', () => {
     expect(screen.getByText(/test-cost-center-artifact/)).toBeInTheDocument();
     expect(screen.queryByText(/test-org-row/)).not.toBeInTheDocument();
     expect(screen.queryByText(/test-cost-center-row/)).not.toBeInTheDocument();
+  });
+
+  it('does not use full-upload metadata when the filtered user is absent', () => {
+    const contextValue = {
+      usageArtifacts: makeUsageArtifacts([
+        {
+          user: 'test-user-one',
+          totalRequests: 50,
+          organization: 'test-org-full-upload',
+          costCenter: 'test-cost-center-full-upload',
+        },
+      ]),
+    } as React.ContextType<typeof AnalysisContext>;
+
+    render(
+      <AnalysisContext.Provider value={contextValue}>
+        <UserDetailsView
+          user="test-user-one"
+          processedData={[]}
+          userQuotaValue={PRICING.BUSINESS_QUOTA}
+          userAggregate={null}
+          onBack={mockOnBack}
+        />
+      </AnalysisContext.Provider>
+    );
+
+    expect(screen.queryByText(/test-org-full-upload/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/test-cost-center-full-upload/)).not.toBeInTheDocument();
+    expect(screen.getByText(/0\s*\/\s*300/)).toBeInTheDocument();
   });
 
   it('renders Spark as a separate billing product bucket', async () => {

--- a/__tests__/components/UserDetailsView.test.tsx
+++ b/__tests__/components/UserDetailsView.test.tsx
@@ -95,6 +95,36 @@ describe('UserDetailsView', () => {
     });
   });
 
+  it('uses the filtered user aggregate for organization and cost center metadata', () => {
+    const processedData = createMockProcessedData([PRICING.BUSINESS_QUOTA]).map((row) => ({
+      ...row,
+      user: 'test-user-one',
+      organization: 'test-org-row',
+      costCenter: 'test-cost-center-row',
+    }));
+
+    render(
+      <UserDetailsView
+        user="test-user-one"
+        processedData={processedData}
+        userQuotaValue={PRICING.BUSINESS_QUOTA}
+        userAggregate={{
+          user: 'test-user-one',
+          totalRequests: 1,
+          modelBreakdown: { 'test-model-one': 1 },
+          organization: 'test-org-artifact',
+          costCenter: 'test-cost-center-artifact',
+        }}
+        onBack={mockOnBack}
+      />
+    );
+
+    expect(screen.getByText(/test-org-artifact/)).toBeInTheDocument();
+    expect(screen.getByText(/test-cost-center-artifact/)).toBeInTheDocument();
+    expect(screen.queryByText(/test-org-row/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/test-cost-center-row/)).not.toBeInTheDocument();
+  });
+
   it('renders Spark as a separate billing product bucket', async () => {
     const timestamp = new Date('2025-06-10T10:00:00Z');
     const iso = timestamp.toISOString();

--- a/src/components/UserDetailsView.tsx
+++ b/src/components/UserDetailsView.tsx
@@ -7,6 +7,7 @@ import { AnalysisContext } from '@/context/AnalysisContext';
 import { UserDailyStackedChart } from '@/components/charts/UserDailyStackedChart';
 import { utcDateLabelFormatter } from '@/components/charts/chartTooltipStyles';
 import type { ProcessedData, UserDailyData } from '@/types/csv';
+import type { UserSummary } from '@/utils/analytics';
 import { getQuotaTier, isLegacyPremiumRequestQuotaValue } from '@/utils/analytics/quota';
 import {
   buildUserDailyAicModelDataFromArtifacts,
@@ -58,6 +59,7 @@ export interface UserDetailsViewProps {
   user: string;
   processedData: ProcessedData[];
   userQuotaValue: number | 'unknown';
+  userAggregate?: UserSummary;
   onBack: () => void;
 }
 
@@ -107,6 +109,7 @@ export function UserDetailsView({
   user,
   processedData,
   userQuotaValue,
+  userAggregate,
   onBack,
 }: UserDetailsViewProps) {
   const analysisCtx = useContext(AnalysisContext);
@@ -214,24 +217,31 @@ export function UserDetailsView({
     return result;
   }, [processedData, user, usageArtifacts, dailyBucketsArtifacts, isUserUsageBasedBilling]);
 
-  const { organization, costCenter } = useMemo(
-    () => getUserOrgMetadata(processedData, user),
-    [processedData, user]
+  const effectiveUserAggregate = useMemo(
+    () => userAggregate ?? usageArtifacts?.users.find((entry) => entry.user === user),
+    [user, userAggregate, usageArtifacts]
   );
+  const { organization, costCenter } = useMemo(() => {
+    if (effectiveUserAggregate) {
+      return {
+        organization: effectiveUserAggregate.organization,
+        costCenter: effectiveUserAggregate.costCenter,
+      };
+    }
+
+    return getUserOrgMetadata(processedData, user);
+  }, [effectiveUserAggregate, processedData, user]);
 
   const userModels = useMemo(() => Array.from(new Set(userData.map((entry) => entry.model))).sort(), [userData]);
   const modelColors = useMemo(() => generateModelColors(userModels), [userModels]);
 
   const userTotalRequests = useMemo(() => {
-    if (usageArtifacts) {
-      const aggregate = usageArtifacts.users.find((entry) => entry.user === user);
-      if (aggregate) {
-        return aggregate.totalRequests;
-      }
+    if (effectiveUserAggregate) {
+      return effectiveUserAggregate.totalRequests;
     }
 
     return calculateUserTotalRequests(processedData, user);
-  }, [processedData, user, usageArtifacts]);
+  }, [effectiveUserAggregate, processedData, user]);
 
   const requestQuotaValue = isLegacyPremiumRequestQuotaValue(effectiveUserQuotaValue)
     ? effectiveUserQuotaValue

--- a/src/components/UserDetailsView.tsx
+++ b/src/components/UserDetailsView.tsx
@@ -59,7 +59,7 @@ export interface UserDetailsViewProps {
   user: string;
   processedData: ProcessedData[];
   userQuotaValue: number | 'unknown';
-  userAggregate?: UserSummary;
+  userAggregate?: UserSummary | null;
   onBack: () => void;
 }
 
@@ -218,7 +218,9 @@ export function UserDetailsView({
   }, [processedData, user, usageArtifacts, dailyBucketsArtifacts, isUserUsageBasedBilling]);
 
   const effectiveUserAggregate = useMemo(
-    () => userAggregate ?? usageArtifacts?.users.find((entry) => entry.user === user),
+    () => userAggregate === undefined
+      ? usageArtifacts?.users.find((entry) => entry.user === user)
+      : userAggregate ?? undefined,
     [user, userAggregate, usageArtifacts]
   );
   const { organization, costCenter } = useMemo(() => {

--- a/src/components/UsersOverview.tsx
+++ b/src/components/UsersOverview.tsx
@@ -261,6 +261,10 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, da
     sortedUserData.slice(activePage * ROWS_PER_PAGE, (activePage + 1) * ROWS_PER_PAGE),
     [sortedUserData, activePage]
   );
+  const selectedUserAggregate = useMemo(
+    () => userData.find((entry) => entry.user === selectedUser),
+    [selectedUser, userData]
+  );
 
   // Reset to first page when sorting changes
   const handleSortWithReset = (column: ColumnKey) => {
@@ -274,6 +278,7 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, da
         user={selectedUser}
         processedData={processedData}
         userQuotaValue={getUserQuota(quotaArtifacts, selectedUser)}
+        userAggregate={selectedUserAggregate}
         onBack={() => setSelectedUser(null)}
       />
     );

--- a/src/components/UsersOverview.tsx
+++ b/src/components/UsersOverview.tsx
@@ -278,7 +278,7 @@ export function UsersOverview({ userData, processedData, dailyCumulativeData, da
         user={selectedUser}
         processedData={processedData}
         userQuotaValue={getUserQuota(quotaArtifacts, selectedUser)}
-        userAggregate={selectedUserAggregate}
+        userAggregate={selectedUserAggregate ?? null}
         onBack={() => setSelectedUser(null)}
       />
     );


### PR DESCRIPTION
## Summary

Reuse the billing-period-filtered user aggregate for user detail metadata and request totals, avoiding a redundant scan of `processedData` while preserving legacy fallbacks. This intentionally passes the filtered aggregate from `UsersOverview` rather than relying only on context artifacts, which cover the full uploaded dataset and can differ from the selected billing period. An explicit `null` sentinel prevents a user absent from the selected period from falling back to full-upload metadata.

| Commit | Change |
|--------|--------|
| `refactor: reuse filtered user metadata aggregate` | Use the filtered aggregate as the source of organization, cost center, and request totals; retain context and row-based fallbacks |
| `fix: preserve filtered user absence` | Distinguish an absent filtered user from an omitted aggregate source so full-upload context data cannot leak into the selected period |

## Validation

- `npm run build`
- `npm run lint` (passes with one pre-existing warning in `AdvisorySection.tsx`)
- `npm run test -- --runInBand` (299 passed, 1 skipped)

Closes #217