### PR TITLE
Support per-model token breakdown from the usage report

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ date,username,product,sku,model,quantity,unit_type,applied_cost_per_quantity,gro
 - `applied_cost_per_quantity`, `gross_amount`, `discount_amount`, `net_amount`
 - `exceeds_quota`, `total_monthly_quota`
 - `product`, `sku`, `organization`, `cost_center_name`
+
+**Optional token columns** (auto-detected when present):
+- `input`, `output`, `cache_read`, `cache_write`
+
+All token fields are optional, so legacy reports remain fully operational. Blank or malformed token cells do not reject an otherwise valid row, and an unavailable value remains distinguishable from a reported `0`.
+
+### Token views
+
+When token fields are present, the **Models** dashboard shows a token summary with total tokens and the four fields: input tokens, output tokens, cache-read tokens, and cache-write tokens. Its per-model table is ordered by total tokens and shows each token type as a count with its share of that model's total in brackets.
+
+The **Models** dashboard also includes a UTC daily token chart with a local model selector. Dates remain in UTC and are never converted to local time. When token fields are present, the **AI Usage** dashboard adds them to the Top Spend Drivers table for per-user context.
+
+Token values are reported by the export. The total is the sum of the four reported fields and is used only to calculate each field's share for that model. Token values are not used to reconstruct or infer billing, cost, savings, or allocation.
+
 ## What You Get
 - Per-user request breakdown with quota status
 - Model usage distribution charts

--- a/__tests__/components/AiUsageOverview.test.tsx
+++ b/__tests__/components/AiUsageOverview.test.tsx
@@ -1,0 +1,95 @@
+import '@testing-library/jest-dom';
+import { render, screen, within } from '@testing-library/react';
+import type React from 'react';
+
+import { AiUsageOverview } from '@/components/AiUsageOverview';
+import { AnalysisContext } from '@/context/AnalysisContext';
+import type { BillingArtifacts, TokenUsageArtifacts } from '@/utils/ingestion';
+
+function createBillingArtifacts(): BillingArtifacts {
+  return {
+    totals: {
+      gross: 0,
+      discount: 0,
+      net: 0,
+      aicQuantity: 17,
+      aicGrossAmount: 0,
+      aicIncludedCredits: 0,
+      aicAdditionalUsageGrossAmount: 0,
+    },
+    overage: { requests: 0, cost: 0, hasBilledOverageData: false },
+    users: [
+      { user: 'test-user-alpha', quantity: 0, overage: { requests: 0, cost: 0, hasBilledOverageData: false }, aicQuantity: 10 },
+      { user: 'test-user-beta', quantity: 0, overage: { requests: 0, cost: 0, hasBilledOverageData: false }, aicQuantity: 5 },
+      { user: 'test-user-gamma', quantity: 0, overage: { requests: 0, cost: 0, hasBilledOverageData: false }, aicQuantity: 2 },
+    ],
+    userMap: new Map(),
+    orgTotals: new Map(),
+    costCenterTotals: new Map(),
+    billingByModel: new Map(),
+    hasAnyBillingData: false,
+    hasAnyAicData: true,
+  };
+}
+
+function createTokenUsageArtifacts(): TokenUsageArtifacts {
+  return {
+    overall: {},
+    byModel: new Map(),
+    byUser: new Map([
+      ['test-user-alpha', { inputTokens: 0, outputTokens: 3, cacheWriteTokens: 9 }],
+      ['test-user-beta', { cacheReadTokens: 5 }],
+    ]),
+    byDayAndModel: new Map(),
+    tokenRowCount: 2,
+    hasTokenData: true,
+  };
+}
+
+function renderOverview(tokenUsageArtifacts?: TokenUsageArtifacts) {
+  const contextValue = {
+    billingArtifacts: createBillingArtifacts(),
+    tokenUsageArtifacts,
+  } as React.ContextType<typeof AnalysisContext>;
+
+  render(
+    <AnalysisContext.Provider value={contextValue}>
+      <AiUsageOverview />
+    </AnalysisContext.Provider>
+  );
+}
+
+describe('AiUsageOverview', () => {
+  it('adds separately reported token fields to the source-AI-credit-ranked drivers', () => {
+    renderOverview(createTokenUsageArtifacts());
+
+    const table = screen.getByRole('table', { name: 'Users ranked by AI Credits consumption' });
+    for (const label of ['Input tokens', 'Output tokens', 'Cache-read tokens', 'Cache-write tokens']) {
+      expect(within(table).getByRole('columnheader', { name: label })).toBeInTheDocument();
+    }
+
+    const rows = within(table).getAllByRole('row');
+    expect(rows[1]).toHaveTextContent('1');
+    expect(rows[1]).toHaveTextContent('test-user-alpha');
+    expect(rows[1]).toHaveTextContent('10.00');
+    expect(rows[1]).toHaveTextContent('0');
+    expect(rows[1]).toHaveTextContent('3');
+    expect(rows[1]).toHaveTextContent('N/A');
+    expect(rows[1]).toHaveTextContent('9');
+    expect(rows[2]).toHaveTextContent('test-user-beta');
+    expect(rows[2]).toHaveTextContent('5.00');
+    expect(rows[2]).toHaveTextContent('N/A');
+    expect(rows[2]).toHaveTextContent('5');
+    expect(rows[3]).toHaveTextContent('test-user-gamma');
+    expect(rows[3]).toHaveTextContent('2.00');
+    expect(rows[3]).toHaveTextContent('N/A');
+  });
+
+  it('keeps the legacy driver table unchanged when token data is absent', () => {
+    renderOverview();
+
+    const table = screen.getByRole('table', { name: 'Users ranked by AI Credits consumption' });
+    expect(within(table).queryByRole('columnheader', { name: 'Input tokens' })).not.toBeInTheDocument();
+    expect(within(table).getAllByRole('columnheader')).toHaveLength(4);
+  });
+});

--- a/__tests__/components/DataAnalysisBilling.test.tsx
+++ b/__tests__/components/DataAnalysisBilling.test.tsx
@@ -10,6 +10,7 @@ import {
   FeatureUsageAggregator,
   QuotaAggregator,
   RawDataAggregator,
+  TokenUsageAggregator,
   UsageAggregator,
   normalizeRow,
 } from '@/utils/ingestion';
@@ -38,6 +39,7 @@ function createIngestionResultFromRawRows(rows: CSVData[]): IngestionResult {
     new DailyBucketsAggregator(),
     new FeatureUsageAggregator(),
     new BillingAggregator(),
+    new TokenUsageAggregator(),
     new RawDataAggregator(),
   ];
   const ctx: AggregatorContext = { pricing: PRICING };
@@ -137,6 +139,59 @@ describe('DataAnalysis billing summary', () => {
       expect(summary).toHaveTextContent('1,234');
       expect(summary).toHaveTextContent('AI Credits additional usage gross');
       expect(summary).toHaveTextContent('$4.56');
+    });
+
+  });
+
+  it('renders source token views on Models while legacy reports retain the empty token note', async () => {
+    const tokenRows: CSVData[] = [{
+      date: '2026-03-01',
+      username: 'test-user-one',
+      model: 'test-model-one',
+      quantity: '2',
+      total_monthly_quota: '1000',
+      input: '12',
+      output: '3',
+      cache_read: '2',
+      cache_write: '1',
+      aic_quantity: '4',
+    }];
+    const { unmount } = render(
+      <DataAnalysis
+        ingestionResult={createIngestionResultFromRawRows(tokenRows)}
+        filename="source-tokens.csv"
+        onReset={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Models' })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByRole('table', { name: 'Per-model token breakdown' })).toBeInTheDocument();
+      expect(screen.queryByText('Token details are not included in this report.')).not.toBeInTheDocument();
+    });
+
+    unmount();
+
+    render(
+      <DataAnalysis
+        ingestionResult={createIngestionResultFromRawRows([{
+          date: '2026-03-01',
+          username: 'test-user-two',
+          model: 'test-model-two',
+          quantity: '2',
+          total_monthly_quota: '1000',
+        }])}
+        filename="legacy.csv"
+        onReset={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Models' })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Model Usage Trends' })).toBeInTheDocument();
+      expect(screen.getByText('Token details are not included in this report.')).toBeInTheDocument();
     });
   });
 

--- a/__tests__/components/TokenUsageOverview.test.tsx
+++ b/__tests__/components/TokenUsageOverview.test.tsx
@@ -1,0 +1,164 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+
+import { TokenUsageOverview } from '@/components/TokenUsageOverview';
+import type { TokenBreakdown, TokenUsageArtifacts } from '@/utils/ingestion';
+
+jest.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  BarChart: ({ children }: { children: React.ReactNode }) => <div data-testid="token-types-chart">{children}</div>,
+  LineChart: ({ children, data }: { children: React.ReactNode; data: unknown }) => (
+    <div data-testid="daily-token-chart">
+      <output data-testid="daily-token-chart-data">{JSON.stringify(data)}</output>
+      {children}
+    </div>
+  ),
+  Bar: ({ name }: { name: string }) => <span data-testid="token-bar-series">{name}</span>,
+  Line: ({ name }: { name: string }) => <span data-testid="token-line-series">{name}</span>,
+  XAxis: () => <span />,
+  YAxis: () => <span />,
+  CartesianGrid: () => <span />,
+  Tooltip: () => <span />,
+  Legend: () => <span />,
+}));
+
+function createTokenUsageArtifacts(): TokenUsageArtifacts {
+  return {
+    overall: {
+      inputTokens: 0,
+      outputTokens: 5,
+      cacheWriteTokens: 10,
+    },
+    byModel: new Map([
+      ['test-model-beta', { cacheReadTokens: 7 }],
+      ['test-model-alpha', { inputTokens: 0, outputTokens: 5, cacheWriteTokens: 10 }],
+      ['test-model-gamma', { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 }],
+    ]),
+    byUser: new Map(),
+    byDayAndModel: new Map<string, Map<string, TokenBreakdown>>([
+      ['2026-03-01', new Map([
+        ['test-model-alpha', { inputTokens: 0, outputTokens: 5 }],
+        ['test-model-beta', { cacheReadTokens: 3 }],
+      ])],
+      ['2026-03-02', new Map([
+        ['test-model-alpha', { cacheWriteTokens: 10 }],
+        ['test-model-beta', { cacheReadTokens: 4 }],
+      ])],
+    ]),
+    tokenRowCount: 3,
+    hasTokenData: true,
+  };
+}
+
+describe('TokenUsageOverview', () => {
+  it('renders token totals, shares, and models ordered by total tokens', () => {
+    render(<TokenUsageOverview tokenUsageArtifacts={createTokenUsageArtifacts()} />);
+
+    const summary = screen.getByRole('heading', { name: 'Token summary' }).parentElement?.parentElement;
+    expect(summary).not.toBeNull();
+    expect(within(summary as HTMLElement).getByText('Total tokens')).toBeInTheDocument();
+    expect(within(summary as HTMLElement).getByText('Input tokens')).toBeInTheDocument();
+    expect(within(summary as HTMLElement).getByText('Output tokens')).toBeInTheDocument();
+    expect(within(summary as HTMLElement).getByText('Cache-read tokens')).toBeInTheDocument();
+    expect(within(summary as HTMLElement).getByText('Cache-write tokens')).toBeInTheDocument();
+    expect(within(summary as HTMLElement).getByText('0')).toBeInTheDocument();
+    expect(within(summary as HTMLElement).getByText('N/A')).toBeInTheDocument();
+    expect(within(summary as HTMLElement).getByText('15')).toBeInTheDocument();
+    const totalCard = within(summary as HTMLElement).getByText('Total tokens').parentElement;
+    const outputCard = within(summary as HTMLElement).getByText('Output tokens').parentElement;
+    expect(totalCard).not.toBeNull();
+    expect(outputCard).not.toBeNull();
+    expect(within(totalCard as HTMLElement).queryByText(/\d+\.\d+\s*%/)).not.toBeInTheDocument();
+    expect(within(outputCard as HTMLElement).getByText('5')).toHaveClass('text-2xl', 'font-semibold', 'text-[#1f2328]');
+    expect(within(outputCard as HTMLElement).getByText(/\(33\.3\s%\)/)).toHaveClass('text-xs', 'text-[#636c76]');
+
+    const table = screen.getByRole('table', { name: 'Per-model token breakdown' });
+    expect(within(table).getAllByRole('columnheader', { name: 'Total tokens' })).toHaveLength(1);
+    expect(within(table).getAllByText('Count; share in brackets')).toHaveLength(4);
+
+    const rows = within(table).getAllByRole('row');
+    expect(rows).toHaveLength(4);
+    expect(rows[1]).toHaveTextContent('test-model-alpha');
+    expect(rows[1]).toHaveTextContent('15');
+    expect(rows[1]).toHaveTextContent('0');
+    expect(rows[1]).toHaveTextContent('N/A');
+    expect(within(rows[1]).getByText('5')).toHaveClass('font-semibold', 'text-[#1f2328]');
+    expect(within(rows[1]).getByText(/\(33\.3\s%\)/)).toHaveClass('text-xs', 'text-[#636c76]');
+    expect(within(rows[1]).getByText(/\(66\.7\s%\)/)).toHaveClass('text-xs', 'text-[#636c76]');
+    expect(rows[2]).toHaveTextContent('test-model-beta');
+    expect(rows[2]).toHaveTextContent('7');
+    expect(rows[2]).toHaveTextContent('7');
+    expect(rows[3]).toHaveTextContent('test-model-gamma');
+    expect(rows[3]).toHaveTextContent('0');
+    expect(rows[3]).not.toHaveTextContent('NaN');
+    expect(within(rows[3]).queryByText(/\d+\.\d+\s*%/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Token split by model' })).not.toBeInTheDocument();
+    expect(screen.queryByText(/Each bar shows how that model/)).not.toBeInTheDocument();
+  });
+
+  it('omits summary card shares when the overall total is zero or a field is unavailable', () => {
+    const tokenUsageArtifacts = createTokenUsageArtifacts();
+    tokenUsageArtifacts.overall = {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+    };
+
+    render(<TokenUsageOverview tokenUsageArtifacts={tokenUsageArtifacts} />);
+
+    const summary = screen.getByRole('heading', { name: 'Token summary' }).parentElement?.parentElement;
+    expect(summary).not.toBeNull();
+    expect(within(summary as HTMLElement).getAllByText('0')).toHaveLength(4);
+    expect(within(summary as HTMLElement).getByText('N/A')).toBeInTheDocument();
+
+    for (const label of ['Input tokens', 'Output tokens', 'Cache-read tokens', 'Cache-write tokens']) {
+      const card = within(summary as HTMLElement).getByText(label).parentElement;
+      expect(card).not.toBeNull();
+      expect(within(card as HTMLElement).queryByText(/\d+\.\d+\s*%/)).not.toBeInTheDocument();
+    }
+  });
+
+  it('uses the visible, local model selector to narrow only the UTC daily chart', () => {
+    render(<TokenUsageOverview tokenUsageArtifacts={createTokenUsageArtifacts()} />);
+
+    const selector = screen.getByLabelText('Model');
+    expect(selector).toHaveValue('all');
+    expect(within(selector).getByRole('option', { name: 'All models' })).toBeInTheDocument();
+    expect(within(selector).getByRole('option', { name: 'test-model-alpha' })).toBeInTheDocument();
+    expect(within(selector).getByRole('option', { name: 'test-model-beta' })).toBeInTheDocument();
+
+    fireEvent.change(selector, { target: { value: 'test-model-beta' } });
+
+    const dailyData = screen.getByTestId('daily-token-chart-data');
+    expect(dailyData).toHaveTextContent('"date":"2026-03-01"');
+    expect(dailyData).toHaveTextContent('"cacheReadTokens":3');
+    expect(dailyData).not.toHaveTextContent('"outputTokens":5');
+    expect(screen.getByRole('table', { name: 'Per-model token breakdown' })).toBeInTheDocument();
+  });
+
+  it('renders the legacy empty note when source token fields are absent', () => {
+    render(
+      <TokenUsageOverview
+        tokenUsageArtifacts={{
+          overall: {},
+          byModel: new Map(),
+          byUser: new Map(),
+          byDayAndModel: new Map(),
+          tokenRowCount: 0,
+          hasTokenData: false,
+        }}
+      />
+    );
+
+    expect(screen.getByText('Token details are not included in this report.')).toBeInTheDocument();
+    expect(screen.queryByRole('table', { name: 'Per-model token breakdown' })).not.toBeInTheDocument();
+  });
+
+  it('keeps token views available without billing artifacts', () => {
+    render(<TokenUsageOverview tokenUsageArtifacts={createTokenUsageArtifacts()} />);
+
+    const table = screen.getByRole('table', { name: 'Per-model token breakdown' });
+    expect(within(table).getByRole('columnheader', { name: 'Total tokens' })).toBeInTheDocument();
+    expect(within(table).getByText('test-model-alpha')).toBeInTheDocument();
+  });
+});

--- a/__tests__/helpers/makeNormalizedRow.ts
+++ b/__tests__/helpers/makeNormalizedRow.ts
@@ -23,6 +23,10 @@ export function makeNormalizedRow(partial: Partial<NormalizedRow> = {}): Normali
     netAmount: partial.netAmount,
     aicQuantity: partial.aicQuantity,
     aicGrossAmount: partial.aicGrossAmount,
+    inputTokens: partial.inputTokens,
+    outputTokens: partial.outputTokens,
+    cacheReadTokens: partial.cacheReadTokens,
+    cacheWriteTokens: partial.cacheWriteTokens,
     isNonCopilotUsage: partial.isNonCopilotUsage ?? false,
     usageBucket: partial.usageBucket,
   };

--- a/__tests__/utils/newFormatParsing.test.ts
+++ b/__tests__/utils/newFormatParsing.test.ts
@@ -317,4 +317,74 @@ describe('processCSVData (CSV format)', () => {
     });
     expect(canonical[0].timestamp.toISOString()).toBe('2025-10-04T00:00:00.000Z');
   });
+
+  it('parses valid source token values, preserves zero, and ignores blank fields', () => {
+    const warnings: string[] = [];
+    const normalized = normalizeRow({
+      date: '2025-10-05',
+      username: 'test-user-one',
+      model: 'test-model-one',
+      quantity: '1',
+      input: '123.45',
+      output: '0',
+      cache_read: '  ',
+      cache_write: '2e2',
+    }, warnings);
+
+    expect(normalized).toMatchObject({
+      inputTokens: 123.45,
+      outputTokens: 0,
+      cacheWriteTokens: 200,
+    });
+    expect(normalized?.cacheReadTokens).toBeUndefined();
+    expect(warnings).toEqual([]);
+  });
+
+  it('keeps valid rows when token fields are malformed, negative, or non-finite', () => {
+    const warnings: string[] = [];
+    const normalized = normalizeRow({
+      date: '2025-10-05',
+      username: 'test-user-one',
+      model: 'test-model-one',
+      quantity: '1',
+      input: '12tokens',
+      output: '-1',
+      cache_read: 'Infinity',
+      cache_write: 'NaN',
+    }, warnings);
+
+    expect(normalized).not.toBeNull();
+    expect(normalized?.inputTokens).toBeUndefined();
+    expect(normalized?.outputTokens).toBeUndefined();
+    expect(normalized?.cacheReadTokens).toBeUndefined();
+    expect(normalized?.cacheWriteTokens).toBeUndefined();
+    expect(warnings).toEqual([
+      'Invalid input token value for user=test-user-one date=2025-10-05',
+      'Invalid output token value for user=test-user-one date=2025-10-05',
+      'Invalid cache_read token value for user=test-user-one date=2025-10-05',
+      'Invalid cache_write token value for user=test-user-one date=2025-10-05',
+    ]);
+  });
+
+  it('preserves source tokens when converting between normalized and processed rows', () => {
+    const normalizedRows: NormalizedRow[] = [{
+      date: '2025-10-06',
+      day: '2025-10-06',
+      user: 'test-user-one',
+      model: 'test-model-one',
+      quantity: 1,
+      inputTokens: 10,
+      outputTokens: 20,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 30,
+    }];
+
+    const processed = buildProcessedDataFromRows(normalizedRows);
+    expect(processed[0]).toMatchObject({
+      inputTokens: 10,
+      outputTokens: 20,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 30,
+    });
+  });
 });

--- a/__tests__/utils/tokenUsageAggregator.test.ts
+++ b/__tests__/utils/tokenUsageAggregator.test.ts
@@ -1,0 +1,142 @@
+import type { ProcessedData } from '@/types/csv';
+import {
+  buildNormalizedRowFromProcessedData,
+  buildTokenUsageArtifactsFromProcessedData,
+  TokenUsageAggregator,
+} from '@/utils/ingestion';
+import type { AggregatorContext, NormalizedRow } from '@/utils/ingestion';
+import { PRICING } from '@/constants/pricing';
+
+import { makeNormalizedRow } from '../helpers/makeNormalizedRow';
+import { makeProcessedData } from '../helpers/testUtils';
+
+describe('TokenUsageAggregator', () => {
+  const ctx: AggregatorContext = { pricing: PRICING };
+
+  function aggregate(rows: NormalizedRow[]) {
+    const aggregator = new TokenUsageAggregator();
+    aggregator.init?.(ctx);
+    rows.forEach(row => aggregator.onRow(row, ctx));
+    return aggregator.finalize(ctx);
+  }
+
+  it('aggregates overall, model, user, and UTC day-model token totals', () => {
+    const artifacts = aggregate([
+      makeNormalizedRow({
+        day: '2025-06-01',
+        user: 'test-user-one',
+        model: 'test-model-one',
+        inputTokens: 10,
+        outputTokens: 5,
+        cacheReadTokens: 2,
+      }),
+      makeNormalizedRow({
+        day: '2025-06-01',
+        user: 'test-user-one',
+        model: 'test-model-one',
+        inputTokens: 3,
+        cacheWriteTokens: 7,
+      }),
+      makeNormalizedRow({
+        day: '2025-06-02',
+        user: 'test-user-two',
+        model: 'test-model-two',
+        outputTokens: 11,
+        cacheReadTokens: 0,
+      }),
+    ]);
+
+    expect(artifacts).toMatchObject({
+      overall: {
+        inputTokens: 13,
+        outputTokens: 16,
+        cacheReadTokens: 2,
+        cacheWriteTokens: 7,
+      },
+      tokenRowCount: 3,
+      hasTokenData: true,
+    });
+    expect(artifacts.byModel.get('test-model-one')).toEqual({
+      inputTokens: 13,
+      outputTokens: 5,
+      cacheReadTokens: 2,
+      cacheWriteTokens: 7,
+    });
+    expect(artifacts.byUser.get('test-user-two')).toEqual({
+      outputTokens: 11,
+      cacheReadTokens: 0,
+    });
+    expect(artifacts.byDayAndModel.get('2025-06-01')?.get('test-model-one')).toEqual({
+      inputTokens: 13,
+      outputTokens: 5,
+      cacheReadTokens: 2,
+      cacheWriteTokens: 7,
+    });
+  });
+
+  it('keeps unavailable token fields undefined and excludes legacy rows from token counts', () => {
+    const artifacts = aggregate([
+      makeNormalizedRow({ user: 'test-user-one', model: 'test-model-one' }),
+      makeNormalizedRow({ user: 'test-user-two', model: 'test-model-two', inputTokens: 0 }),
+    ]);
+
+    expect(artifacts).toEqual({
+      overall: { inputTokens: 0 },
+      byModel: new Map([['test-model-two', { inputTokens: 0 }]]),
+      byUser: new Map([['test-user-two', { inputTokens: 0 }]]),
+      byDayAndModel: new Map([[
+        '2025-06-01',
+        new Map([['test-model-two', { inputTokens: 0 }]]),
+      ]]),
+      tokenRowCount: 1,
+      hasTokenData: true,
+    });
+    expect(artifacts.overall.outputTokens).toBeUndefined();
+    expect(artifacts.overall.cacheReadTokens).toBeUndefined();
+    expect(artifacts.overall.cacheWriteTokens).toBeUndefined();
+  });
+
+  it('returns empty artifacts when no source token values are available', () => {
+    const artifacts = aggregate([makeNormalizedRow()]);
+
+    expect(artifacts).toEqual({
+      overall: {},
+      byModel: new Map(),
+      byUser: new Map(),
+      byDayAndModel: new Map(),
+      tokenRowCount: 0,
+      hasTokenData: false,
+    });
+  });
+
+  it('preserves token values through the processed-data adapter and rebuilds filtered artifacts', () => {
+    const rows: ProcessedData[] = [
+      makeProcessedData({
+        timestamp: new Date('2025-06-30T23:59:59Z'),
+        inputTokens: 10,
+        outputTokens: 5,
+      }),
+      makeProcessedData({
+        timestamp: new Date('2025-07-01T00:00:00Z'),
+        inputTokens: 4,
+        cacheWriteTokens: 2,
+      }),
+    ];
+
+    expect(buildNormalizedRowFromProcessedData(rows[0])).toMatchObject({
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+
+    const juneArtifacts = buildTokenUsageArtifactsFromProcessedData(
+      rows.filter(row => row.monthKey === '2025-06')
+    );
+
+    expect(juneArtifacts.overall).toEqual({ inputTokens: 10, outputTokens: 5 });
+    expect(juneArtifacts.byDayAndModel.get('2025-06-30')?.get('test-model')).toEqual({
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+    expect(juneArtifacts.tokenRowCount).toBe(1);
+  });
+});

--- a/public/data/ai-usage-token-example.csv
+++ b/public/data/ai-usage-token-example.csv
@@ -1,0 +1,9 @@
+date,username,product,sku,model,quantity,unit_type,applied_cost_per_quantity,gross_amount,discount_amount,net_amount,exceeds_quota,total_monthly_quota,organization,cost_center_name,input,output,cache_read,cache_write
+2026-03-01,test-user-one,copilot,copilot_premium_request,Claude Sonnet 4,2,requests,0.04,0.08,0.00,0.08,False,1000,test-org-one,test-cost-center-one,100,20,10,5
+2026-03-02,test-user-two,copilot,copilot_premium_request,GPT-5,1,requests,0.04,0.04,0.00,0.04,False,1000,test-org-one,test-cost-center-two,80,15,8,4
+2026-03-03,test-user-one,copilot,copilot_premium_request,Claude Sonnet 4,3,requests,0.04,0.12,0.00,0.12,False,1000,test-org-one,test-cost-center-one,120,25,12,6
+2026-03-04,test-user-two,copilot,copilot_premium_request,GPT-5,2,requests,0.04,0.08,0.00,0.08,False,1000,test-org-one,test-cost-center-two,90,0,9,3
+2026-03-05,test-user-one,copilot,copilot_premium_request,Claude Sonnet 4,1,requests,0.04,0.04,0.00,0.04,False,1000,test-org-one,test-cost-center-one,110,22,11,5
+2026-03-06,test-user-two,copilot,copilot_premium_request,GPT-5,4,requests,0.04,0.16,0.00,0.16,False,1000,test-org-one,test-cost-center-two,95,19,,4
+2026-03-07,test-user-one,copilot,copilot_premium_request,Claude Sonnet 4,2,requests,0.04,0.08,0.00,0.08,False,1000,test-org-one,test-cost-center-one,105,21,10,5
+2026-03-08,test-user-two,copilot,copilot_premium_request,GPT-5,3,requests,0.04,0.12,0.00,0.12,False,1000,test-org-one,test-cost-center-two,85,18,8,4

--- a/src/components/AiUsageOverview.tsx
+++ b/src/components/AiUsageOverview.tsx
@@ -2,8 +2,9 @@
 
 import { useMemo } from 'react';
 
+import { TOKEN_TYPE_SERIES } from '@/components/charts/tokenUsageChartSeries';
 import { useAnalysisContext } from '@/context/AnalysisContext';
-import type { BillingUserTotals } from '@/utils/ingestion';
+import type { BillingUserTotals, TokenBreakdown, TokenUsageArtifacts } from '@/utils/ingestion';
 import { getEffectiveAicQuantity } from '@/utils/aicFields';
 
 import { UsersAicDistributionChart } from './charts/UsersAicDistributionChart';
@@ -12,6 +13,7 @@ interface RankedAicUser {
   user: string;
   aiCredits: number;
   shareOfTotal: number;
+  tokens?: TokenBreakdown;
 }
 
 interface AicConcentrationRow {
@@ -29,7 +31,14 @@ function formatAiCredits(value: number): string {
   return value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
-function buildRankedAicUsers(users: BillingUserTotals[]): RankedAicUser[] {
+function formatTokenValue(value: number | undefined): string {
+  return value === undefined ? 'N/A' : value.toLocaleString();
+}
+
+function buildRankedAicUsers(
+  users: BillingUserTotals[],
+  tokenUsageArtifacts?: TokenUsageArtifacts
+): RankedAicUser[] {
   const totalAiCredits = users.reduce((sum, user) => sum + getEffectiveAicQuantity(user), 0);
 
   return users
@@ -40,6 +49,7 @@ function buildRankedAicUsers(users: BillingUserTotals[]): RankedAicUser[] {
         user: user.user,
         aiCredits,
         shareOfTotal: totalAiCredits > 0 ? (aiCredits / totalAiCredits) * 100 : 0,
+        tokens: tokenUsageArtifacts?.byUser.get(user.user),
       };
     })
     .filter((user) => user.aiCredits > 0)
@@ -78,10 +88,11 @@ function buildAicConcentrationRows(rankedUsers: RankedAicUser[]): AicConcentrati
 }
 
 export function AiUsageOverview() {
-  const { billingArtifacts } = useAnalysisContext();
+  const { billingArtifacts, tokenUsageArtifacts } = useAnalysisContext();
+  const hasTokenData = tokenUsageArtifacts?.hasTokenData === true;
   const rankedUsers = useMemo(
-    () => buildRankedAicUsers(billingArtifacts?.users ?? []),
-    [billingArtifacts?.users]
+    () => buildRankedAicUsers(billingArtifacts?.users ?? [], hasTokenData ? tokenUsageArtifacts : undefined),
+    [billingArtifacts?.users, hasTokenData, tokenUsageArtifacts]
   );
   const concentrationRows = useMemo(
     () => buildAicConcentrationRows(rankedUsers),
@@ -189,7 +200,10 @@ export function AiUsageOverview() {
           </p>
         </div>
         <div className="overflow-x-auto">
-          <table className="min-w-full" aria-label="Users ranked by AI Credits consumption">
+          <table
+            className={hasTokenData ? 'min-w-[58rem] w-full' : 'min-w-full'}
+            aria-label="Users ranked by AI Credits consumption"
+          >
             <thead>
               <tr className="border-b border-[#d1d9e0]">
                 <th className="w-16 px-4 py-3 text-left text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
@@ -204,6 +218,11 @@ export function AiUsageOverview() {
                 <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">
                   Share
                 </th>
+                {hasTokenData && TOKEN_TYPE_SERIES.map((series) => (
+                  <th key={series.key} className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa] whitespace-nowrap">
+                    {series.label}
+                  </th>
+                ))}
               </tr>
             </thead>
             <tbody className="divide-y divide-[#d1d9e0]">
@@ -222,11 +241,16 @@ export function AiUsageOverview() {
                     <td className="px-5 py-3 whitespace-nowrap text-sm font-mono tabular-nums text-[#636c76] text-right">
                       {formatPercentage(user.shareOfTotal)}
                     </td>
+                    {hasTokenData && TOKEN_TYPE_SERIES.map((series) => (
+                      <td key={series.key} className="px-5 py-3 whitespace-nowrap text-sm font-mono tabular-nums text-[#636c76] text-right">
+                        {formatTokenValue(user.tokens?.[series.key])}
+                      </td>
+                    ))}
                   </tr>
                 ))
               ) : (
                 <tr>
-                  <td colSpan={4} className="px-5 py-8 text-center text-sm text-[#636c76]">
+                  <td colSpan={hasTokenData ? 8 : 4} className="px-5 py-8 text-center text-sm text-[#636c76]">
                     No AI Credits consumption is available for the current users
                   </td>
                 </tr>

--- a/src/components/CSVUploader.tsx
+++ b/src/components/CSVUploader.tsx
@@ -7,6 +7,7 @@ import {
   UsageAggregator,
   DailyBucketsAggregator,
   FeatureUsageAggregator,
+  TokenUsageAggregator,
   BillingAggregator,
   RawDataAggregator,
   IngestionResult
@@ -99,13 +100,14 @@ export function CSVUploader({ onDataLoad, onError }: CSVUploaderProps) {
     const usageAggregator = new UsageAggregator();
     const dailyBucketsAggregator = new DailyBucketsAggregator();
     const featureUsageAggregator = new FeatureUsageAggregator();
+    const tokenUsageAggregator = new TokenUsageAggregator();
     const billingAggregator = new BillingAggregator();
     const rawDataAggregator = new RawDataAggregator();
 
     // Single-pass streaming ingestion with all aggregators
     ingestStream(
       file,
-      [quotaAggregator, usageAggregator, dailyBucketsAggregator, featureUsageAggregator, billingAggregator, rawDataAggregator],
+      [quotaAggregator, usageAggregator, dailyBucketsAggregator, featureUsageAggregator, tokenUsageAggregator, billingAggregator, rawDataAggregator],
       {
         chunkSize: 1024 * 1024, // 1MB chunks for smooth UI
         progressResolution: 1000,

--- a/src/components/ModelUsageTrendsOverview.tsx
+++ b/src/components/ModelUsageTrendsOverview.tsx
@@ -4,6 +4,7 @@ import React, { useMemo } from 'react';
 
 import { useAnalysisContext } from '@/context/AnalysisContext';
 import { ModelDailyStackedChart } from '@/components/charts/ModelDailyStackedChart';
+import { TokenUsageOverview } from '@/components/TokenUsageOverview';
 import { filterDailySeriesByMonths } from '@/utils/analytics/filters';
 import { getEffectiveAicQuantity } from '@/utils/aicFields';
 import { formatCurrency } from '@/utils/formatters';
@@ -24,6 +25,7 @@ export function ModelUsageTrendsOverview() {
     dailyBucketsArtifacts,
     selectedMonths,
     billingArtifacts,
+    tokenUsageArtifacts,
     aggregateProcessedData,
   } = useAnalysisContext();
   const isUsageBasedBilling = useMemo(() => {
@@ -151,6 +153,10 @@ export function ModelUsageTrendsOverview() {
           </div>
         )}
       </div>
+
+      <TokenUsageOverview
+        tokenUsageArtifacts={tokenUsageArtifacts}
+      />
     </div>
   );
 }

--- a/src/components/TokenUsageOverview.tsx
+++ b/src/components/TokenUsageOverview.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+
+import { TokenUsageByDayChart, type TokenUsageByDayChartDatum } from '@/components/charts/TokenUsageByDayChart';
+import { TOKEN_TYPE_SERIES } from '@/components/charts/tokenUsageChartSeries';
+import type { TokenBreakdown, TokenUsageArtifacts } from '@/utils/ingestion';
+
+interface TokenUsageOverviewProps {
+  tokenUsageArtifacts?: TokenUsageArtifacts;
+}
+
+interface TokenModelRow {
+  model: string;
+  tokens: TokenBreakdown;
+  tokenTotal: number;
+}
+
+function formatTokenValue(value: number | undefined): string {
+  return value === undefined ? 'N/A' : value.toLocaleString();
+}
+
+function compareTokenModelRows(left: TokenModelRow, right: TokenModelRow): number {
+  if (right.tokenTotal !== left.tokenTotal) {
+    return right.tokenTotal - left.tokenTotal;
+  }
+
+  return left.model.localeCompare(right.model);
+}
+
+function aggregateTokenBreakdowns(breakdowns: Iterable<TokenBreakdown>): TokenBreakdown {
+  const result: TokenBreakdown = {};
+
+  for (const breakdown of breakdowns) {
+    for (const series of TOKEN_TYPE_SERIES) {
+      const value = breakdown[series.key];
+      if (value !== undefined) {
+        result[series.key] = (result[series.key] ?? 0) + value;
+      }
+    }
+  }
+
+  return result;
+}
+
+function getTokenTotal(tokens: TokenBreakdown): number {
+  return TOKEN_TYPE_SERIES.reduce((total, series) => total + (tokens[series.key] ?? 0), 0);
+}
+
+function formatTokenShare(value: number | undefined, total: number): string | undefined {
+  if (value === undefined || total === 0) {
+    return undefined;
+  }
+
+  return `${((value / total) * 100).toFixed(1)}\u00a0%`;
+}
+
+export function TokenUsageOverview({ tokenUsageArtifacts }: TokenUsageOverviewProps) {
+  const [selectedModel, setSelectedModel] = useState('all');
+  const modelRows = useMemo(() => {
+    if (!tokenUsageArtifacts) {
+      return [];
+    }
+
+    return Array.from(tokenUsageArtifacts.byModel.entries())
+      .map(([model, tokens]) => ({
+        model,
+        tokens,
+        tokenTotal: getTokenTotal(tokens),
+      }))
+      .sort(compareTokenModelRows);
+  }, [tokenUsageArtifacts]);
+
+  const dailyChartData = useMemo((): TokenUsageByDayChartDatum[] => {
+    if (!tokenUsageArtifacts) {
+      return [];
+    }
+
+    return Array.from(tokenUsageArtifacts.byDayAndModel.entries())
+      .sort(([leftDate], [rightDate]) => leftDate.localeCompare(rightDate))
+      .map(([date, byModel]) => ({
+        date,
+        ...(selectedModel === 'all'
+          ? aggregateTokenBreakdowns(byModel.values())
+          : byModel.get(selectedModel) ?? {}),
+      }));
+  }, [selectedModel, tokenUsageArtifacts]);
+
+  if (!tokenUsageArtifacts?.hasTokenData) {
+    return (
+      <div className="p-4 bg-[#f6f8fa] border border-[#d1d9e0] rounded-md">
+        <p className="text-sm text-[#636c76]">Token details are not included in this report.</p>
+      </div>
+    );
+  }
+
+  const overallTokenTotal = getTokenTotal(tokenUsageArtifacts.overall);
+
+  return (
+    <section aria-label="Token details" className="space-y-5">
+      <div className="bg-white border border-[#d1d9e0] rounded-md overflow-hidden">
+        <div className="px-5 py-4 border-b border-[#d1d9e0]">
+          <h4 className="text-sm font-medium text-[#1f2328]">Token summary</h4>
+          <p className="text-xs text-[#636c76] mt-0.5">Token volume is shown by field and total.</p>
+        </div>
+        <dl className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-5 gap-4 p-5">
+          <div className="p-4 bg-[#f6f8fa] border border-[#d1d9e0] rounded-md">
+            <dt className="text-xs font-medium text-[#636c76] uppercase tracking-[0.05em]">Total tokens</dt>
+            <dd className="mt-1 text-2xl font-semibold tabular-nums text-[#1f2328]">
+              {overallTokenTotal.toLocaleString()}
+            </dd>
+          </div>
+          {TOKEN_TYPE_SERIES.map((series) => {
+            const tokenShare = formatTokenShare(tokenUsageArtifacts.overall[series.key], overallTokenTotal);
+
+            return (
+              <div key={series.key} className="p-4 bg-[#f6f8fa] border border-[#d1d9e0] rounded-md">
+                <dt className="text-xs font-medium text-[#636c76] uppercase tracking-[0.05em]">{series.label}</dt>
+                <dd className="mt-1 flex items-baseline gap-1.5">
+                  <span className="text-2xl font-semibold tabular-nums text-[#1f2328]">
+                    {formatTokenValue(tokenUsageArtifacts.overall[series.key])}
+                  </span>
+                  {tokenShare !== undefined && (
+                    <span className="text-xs font-mono tabular-nums text-[#636c76]">
+                      ({tokenShare})
+                    </span>
+                  )}
+                </dd>
+              </div>
+            );
+          })}
+        </dl>
+      </div>
+
+      <div className="bg-white border border-[#d1d9e0] rounded-md overflow-hidden">
+        <div className="px-5 py-4 border-b border-[#d1d9e0]">
+          <h4 className="text-sm font-medium text-[#1f2328]">Per-model token breakdown</h4>
+          <p className="text-xs text-[#636c76] mt-0.5">Models are ordered by total tokens.</p>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-[56rem] w-full" aria-label="Per-model token breakdown">
+            <thead>
+              <tr className="border-b border-[#d1d9e0]">
+                <th className="px-5 py-3 text-left text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa]">Model</th>
+                <th className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa] whitespace-nowrap">Total tokens</th>
+                {TOKEN_TYPE_SERIES.map((series) => (
+                  <th key={series.key} className="px-5 py-3 text-right text-[11px] font-semibold text-[#636c76] uppercase tracking-wider bg-[#f6f8fa] whitespace-nowrap">
+                    <span className="block">{series.label}</span>
+                    <span className="block mt-0.5 text-[10px] font-medium normal-case tracking-normal text-[#636c76]">
+                      Count; share in brackets
+                    </span>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[#d1d9e0]">
+              {modelRows.map((row) => (
+                <tr key={row.model} className="hover:bg-[#fcfdff] transition-colors">
+                  <td className="px-5 py-3 text-sm font-medium text-[#1f2328] whitespace-nowrap">{row.model}</td>
+                  <td className="px-5 py-3 text-sm font-mono font-semibold tabular-nums text-[#1f2328] text-right bg-[#f6f8fa] whitespace-nowrap">
+                    {row.tokenTotal.toLocaleString()}
+                  </td>
+                  {TOKEN_TYPE_SERIES.map((series) => {
+                    const tokenShare = formatTokenShare(row.tokens[series.key], row.tokenTotal);
+
+                    return (
+                      <td key={series.key} className="px-5 py-3 text-right whitespace-nowrap">
+                        {tokenShare !== undefined ? (
+                          <div className="flex items-baseline justify-end gap-1.5">
+                            <span className="text-sm font-mono font-semibold tabular-nums text-[#1f2328]">
+                              {formatTokenValue(row.tokens[series.key])}
+                            </span>
+                            <span className="text-xs font-mono tabular-nums text-[#636c76]">
+                              ({tokenShare})
+                            </span>
+                          </div>
+                        ) : (
+                          <span className="text-sm font-mono font-semibold tabular-nums text-[#1f2328]">
+                            {formatTokenValue(row.tokens[series.key])}
+                          </span>
+                        )}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div className="bg-white border border-[#d1d9e0] rounded-md p-5 min-h-[20rem]">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h4 className="text-sm font-medium text-[#1f2328]">Daily source token usage</h4>
+            <p className="text-xs text-[#636c76] mt-0.5">UTC source-report fields by day.</p>
+          </div>
+          <div className="flex flex-col gap-1.5 text-sm text-[#636c76]">
+            <label htmlFor="token-model-selector" className="font-medium text-[#1f2328]">Model</label>
+            <select
+              id="token-model-selector"
+              value={selectedModel}
+              onChange={(event) => setSelectedModel(event.target.value)}
+              className="min-w-56 rounded-md border border-[#d1d9e0] bg-white px-3 py-2 text-sm text-[#1f2328] shadow-sm outline-none transition duration-150 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-100"
+            >
+              <option value="all">All models</option>
+              {modelRows.map((row) => (
+                <option key={row.model} value={row.model}>{row.model}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+        <div className="mt-4 h-72 sm:h-96 2xl:h-[28rem] w-full">
+          <TokenUsageByDayChart data={dailyChartData} />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/charts/TokenUsageByDayChart.tsx
+++ b/src/components/charts/TokenUsageByDayChart.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import React from 'react';
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import { chartTooltipContentStyle, chartTooltipLabelStyle, utcDateTickFormatter } from './chartTooltipStyles';
+import { TOKEN_TYPE_SERIES, type TokenTypeKey } from './tokenUsageChartSeries';
+
+export interface TokenUsageByDayChartDatum {
+  date: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+}
+
+interface TokenUsageByDayChartProps {
+  data: TokenUsageByDayChartDatum[];
+}
+
+function formatTokenValue(value: unknown): string {
+  return Number(value).toLocaleString();
+}
+
+export function TokenUsageByDayChart({ data }: TokenUsageByDayChartProps) {
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <LineChart data={data} margin={{ top: 16, right: 24, left: 12, bottom: 8 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+        <XAxis
+          dataKey="date"
+          tick={{ fontSize: 12, fill: '#636c76' }}
+          axisLine={{ stroke: '#d1d9e0' }}
+          tickLine={{ stroke: '#d1d9e0' }}
+          tickFormatter={utcDateTickFormatter}
+        />
+        <YAxis
+          tick={{ fontSize: 12, fill: '#636c76' }}
+          axisLine={{ stroke: '#d1d9e0' }}
+          tickLine={{ stroke: '#d1d9e0' }}
+        />
+        <Tooltip
+          contentStyle={chartTooltipContentStyle}
+          labelStyle={chartTooltipLabelStyle}
+          labelFormatter={(value) => String(value)}
+          formatter={(value, name) => [formatTokenValue(value), String(name)]}
+          wrapperStyle={{ zIndex: 1000 }}
+          cursor={{ stroke: '#6366f1', strokeDasharray: '3 3' }}
+        />
+        <Legend wrapperStyle={{ fontSize: 12, color: '#636c76' }} />
+        {TOKEN_TYPE_SERIES.map((series) => (
+          <Line
+            key={series.key}
+            type="monotone"
+            dataKey={series.key as TokenTypeKey}
+            name={series.label}
+            stroke={series.color}
+            strokeWidth={2}
+            dot={false}
+            activeDot={{ r: 4 }}
+            connectNulls={false}
+          />
+        ))}
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/charts/tokenUsageChartSeries.ts
+++ b/src/components/charts/tokenUsageChartSeries.ts
@@ -1,0 +1,8 @@
+export const TOKEN_TYPE_SERIES = [
+  { key: 'inputTokens', label: 'Input tokens', color: '#6366f1' },
+  { key: 'outputTokens', label: 'Output tokens', color: '#22c55e' },
+  { key: 'cacheReadTokens', label: 'Cache-read tokens', color: '#f59e0b' },
+  { key: 'cacheWriteTokens', label: 'Cache-write tokens', color: '#06b6d4' },
+] as const;
+
+export type TokenTypeKey = (typeof TOKEN_TYPE_SERIES)[number]['key'];

--- a/src/context/AnalysisContext.tsx
+++ b/src/context/AnalysisContext.tsx
@@ -13,9 +13,11 @@ import {
   DailyBucketsArtifacts,
   FeatureUsageArtifacts,
   BillingArtifacts,
+  TokenUsageArtifacts,
   NormalizedRow,
   buildBillingArtifactsFromProcessedData,
-  buildProcessedDataFromRows
+  buildProcessedDataFromRows,
+  buildTokenUsageArtifactsFromProcessedData
 } from '@/utils/ingestion';
 
 // Types
@@ -41,6 +43,7 @@ interface AnalysisContextValue {
   dailyBucketsArtifacts: DailyBucketsArtifacts;
   featureUsageArtifacts: FeatureUsageArtifacts;
   billingArtifacts?: BillingArtifacts; // new billing summary artifacts
+  tokenUsageArtifacts?: TokenUsageArtifacts;
   
   // Raw & processed (adapter bridge - to be phased out)
   baseProcessed: ProcessedData[];
@@ -135,13 +138,14 @@ export function AnalysisProvider({ ingestionResult, filename, onReset, children 
   const [view, setView] = useState<ViewType>('overview');
 
   // Extract aggregator outputs
-  const { quotaArtifacts, usageArtifacts, dailyBucketsArtifacts, featureUsageArtifacts, billingArtifacts } = useMemo(() => {
+  const { quotaArtifacts, usageArtifacts, dailyBucketsArtifacts, featureUsageArtifacts, billingArtifacts, tokenUsageArtifacts } = useMemo(() => {
     return {
       quotaArtifacts: ingestionResult.outputs.quota as QuotaArtifacts,
       usageArtifacts: ingestionResult.outputs.usage as UsageArtifacts,
       dailyBucketsArtifacts: ingestionResult.outputs.dailyBuckets as DailyBucketsArtifacts,
       featureUsageArtifacts: requireFeatureUsageArtifacts(ingestionResult.outputs.featureUsage),
-      billingArtifacts: withBillingArtifactDefaults(ingestionResult.outputs.billing as BillingArtifacts | undefined)
+      billingArtifacts: withBillingArtifactDefaults(ingestionResult.outputs.billing as BillingArtifacts | undefined),
+      tokenUsageArtifacts: ingestionResult.outputs.tokenUsage as TokenUsageArtifacts | undefined
     };
   }, [ingestionResult]);
 
@@ -183,6 +187,12 @@ export function AnalysisProvider({ ingestionResult, filename, onReset, children 
       : billingArtifacts
   ), [aggregateProcessedData, baseProcessed.length, billingArtifacts]);
 
+  const effectiveTokenUsageArtifacts = useMemo(() => (
+    baseProcessed.length > 0
+      ? buildTokenUsageArtifactsFromProcessedData(aggregateProcessedData)
+      : tokenUsageArtifacts
+  ), [aggregateProcessedData, baseProcessed.length, tokenUsageArtifacts]);
+
   // Use the suggested plan from data (auto-derived from report content)
   const selectedPlan = analysis.quotaBreakdown.suggestedPlan ?? 'business';
 
@@ -214,6 +224,7 @@ export function AnalysisProvider({ ingestionResult, filename, onReset, children 
     dailyBucketsArtifacts,
     featureUsageArtifacts,
     billingArtifacts: effectiveBillingArtifacts,
+    tokenUsageArtifacts: effectiveTokenUsageArtifacts,
     // Legacy adapter bridge
     baseProcessed,
     processedData,

--- a/src/types/csv.ts
+++ b/src/types/csv.ts
@@ -18,6 +18,10 @@ export interface CSVData {
   cost_center_name?: string;
   aic_quantity?: string; // numeric string
   aic_gross_amount?: string; // numeric string
+  input?: string; // source token count
+  output?: string; // source token count
+  cache_read?: string; // source token count
+  cache_write?: string; // source token count
 }
 
 // Processed record produced from CSV row.
@@ -48,6 +52,10 @@ export interface ProcessedData {
   netAmount?: number;
   aicQuantity?: number;
   aicGrossAmount?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
   isNonCopilotUsage?: boolean;
   usageBucket?: 'non_copilot_code_review';
 }

--- a/src/utils/ingestion/TokenUsageAggregator.ts
+++ b/src/utils/ingestion/TokenUsageAggregator.ts
@@ -1,0 +1,95 @@
+/**
+ * TokenUsageAggregator
+ * ---------------------------------
+ * Accumulates source-reported token counts while preserving unavailable fields.
+ */
+
+import {
+  Aggregator,
+  AggregatorContext,
+  NormalizedRow,
+  TokenBreakdown,
+  TokenUsageArtifacts,
+} from './types';
+
+type TokenField = keyof TokenBreakdown;
+
+const TOKEN_FIELDS: TokenField[] = [
+  'inputTokens',
+  'outputTokens',
+  'cacheReadTokens',
+  'cacheWriteTokens',
+];
+
+function addTokenValues(target: TokenBreakdown, row: NormalizedRow): boolean {
+  let hasTokenValue = false;
+
+  for (const field of TOKEN_FIELDS) {
+    const value = row[field];
+    if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+      target[field] = (target[field] ?? 0) + value;
+      hasTokenValue = true;
+    }
+  }
+
+  return hasTokenValue;
+}
+
+export class TokenUsageAggregator implements Aggregator<TokenUsageArtifacts> {
+  readonly id = 'tokenUsage';
+
+  private overall: TokenBreakdown = {};
+  private byModel = new Map<string, TokenBreakdown>();
+  private byUser = new Map<string, TokenBreakdown>();
+  private byDayAndModel = new Map<string, Map<string, TokenBreakdown>>();
+  private tokenRowCount = 0;
+
+  init(_ctx: AggregatorContext): void {
+    void _ctx;
+    this.overall = {};
+    this.byModel = new Map();
+    this.byUser = new Map();
+    this.byDayAndModel = new Map();
+    this.tokenRowCount = 0;
+  }
+
+  onRow(row: NormalizedRow, _ctx: AggregatorContext): void {
+    void _ctx;
+    if (!addTokenValues(this.overall, row)) {
+      return;
+    }
+
+    this.tokenRowCount++;
+    this.addToGroup(this.byModel, row.model, row);
+    this.addToGroup(this.byUser, row.user, row);
+
+    let modelsForDay = this.byDayAndModel.get(row.day);
+    if (!modelsForDay) {
+      modelsForDay = new Map();
+      this.byDayAndModel.set(row.day, modelsForDay);
+    }
+    this.addToGroup(modelsForDay, row.model, row);
+  }
+
+  finalize(_ctx: AggregatorContext): TokenUsageArtifacts {
+    void _ctx;
+    return {
+      overall: this.overall,
+      byModel: this.byModel,
+      byUser: this.byUser,
+      byDayAndModel: this.byDayAndModel,
+      tokenRowCount: this.tokenRowCount,
+      hasTokenData: this.tokenRowCount > 0,
+    };
+  }
+
+  private addToGroup(
+    groups: Map<string, TokenBreakdown>,
+    key: string,
+    row: NormalizedRow
+  ): void {
+    const breakdown = groups.get(key) ?? {};
+    addTokenValues(breakdown, row);
+    groups.set(key, breakdown);
+  }
+}

--- a/src/utils/ingestion/adapters.ts
+++ b/src/utils/ingestion/adapters.ts
@@ -65,6 +65,10 @@ export function buildProcessedDataFromRows(
       netAmount: row.netAmount,
       aicQuantity: row.aicQuantity,
       aicGrossAmount: row.aicGrossAmount,
+      inputTokens: row.inputTokens,
+      outputTokens: row.outputTokens,
+      cacheReadTokens: row.cacheReadTokens,
+      cacheWriteTokens: row.cacheWriteTokens,
       isNonCopilotUsage: row.isNonCopilotUsage,
       usageBucket: row.usageBucket,
       ...keys

--- a/src/utils/ingestion/analytics.ts
+++ b/src/utils/ingestion/analytics.ts
@@ -28,10 +28,12 @@ import {
   type FeatureUsageArtifacts,
   type NormalizedRow,
   type QuotaArtifacts,
+  type TokenUsageArtifacts,
   type UsageArtifacts,
 } from './types';
 import { DailyBucketsAggregator } from './DailyBucketsAggregator';
 import { QuotaAggregator } from './QuotaAggregator';
+import { TokenUsageAggregator } from './TokenUsageAggregator';
 import { UsageAccumulator } from './UsageAccumulator';
 
 export type { DailyBucketsArtifacts } from './types';
@@ -137,6 +139,10 @@ export function buildNormalizedRowFromProcessedData(row: ProcessedData): Normali
     netAmount: row.netAmount,
     aicQuantity: row.aicQuantity,
     aicGrossAmount: row.aicGrossAmount,
+    inputTokens: row.inputTokens,
+    outputTokens: row.outputTokens,
+    cacheReadTokens: row.cacheReadTokens,
+    cacheWriteTokens: row.cacheWriteTokens,
     isNonCopilotUsage: row.isNonCopilotUsage,
     usageBucket: row.usageBucket,
   };
@@ -161,6 +167,10 @@ export function buildQuotaArtifactsFromProcessedData(processed: ProcessedData[])
 
 export function buildDailyBucketsArtifactsFromProcessedData(processed: ProcessedData[]): DailyBucketsArtifacts {
   return runAggregatorOverProcessedData(new DailyBucketsAggregator(), processed);
+}
+
+export function buildTokenUsageArtifactsFromProcessedData(processed: ProcessedData[]): TokenUsageArtifacts {
+  return runAggregatorOverProcessedData(new TokenUsageAggregator(), processed);
 }
 
 /**

--- a/src/utils/ingestion/index.ts
+++ b/src/utils/ingestion/index.ts
@@ -13,6 +13,7 @@ export * from './DailyBucketsAggregator';
 export * from './BillingAggregator';
 export * from './billingAccumulator';
 export * from './FeatureUsageAggregator';
+export * from './TokenUsageAggregator';
 export * from './RawDataAggregator';
 export * from './adapters';
 export * from './analytics';

--- a/src/utils/ingestion/normalizeRow.ts
+++ b/src/utils/ingestion/normalizeRow.ts
@@ -49,7 +49,11 @@ export function normalizeRow(
     discount_amount,
     net_amount,
     aic_quantity,
-    aic_gross_amount
+    aic_gross_amount,
+    input,
+    output,
+    cache_read,
+    cache_write
   } = rawRecord;
   
   // Type guard and validate required fields
@@ -114,6 +118,34 @@ export function normalizeRow(
     return Object.prototype.hasOwnProperty.call(rawRecord, fieldName) ? 0 : undefined;
   };
   const grossAmountValue = parseRequestBillingAmount('gross_amount', gross_amount);
+  const parseTokenCount = (fieldName: string, value: unknown): number | undefined => {
+    if (value === undefined || value === null) {
+      return undefined;
+    }
+
+    if (typeof value !== 'string') {
+      warnings.push(`Invalid ${fieldName} token value for user=${username} date=${date}`);
+      return undefined;
+    }
+
+    const trimmed = value.trim();
+    if (trimmed === '') {
+      return undefined;
+    }
+
+    if (!/^(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/.test(trimmed)) {
+      warnings.push(`Invalid ${fieldName} token value for user=${username} date=${date}`);
+      return undefined;
+    }
+
+    const parsed = Number(trimmed);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      warnings.push(`Invalid ${fieldName} token value for user=${username} date=${date}`);
+      return undefined;
+    }
+
+    return parsed;
+  };
 
   return {
     date: isoDate,
@@ -141,6 +173,10 @@ export function normalizeRow(
     netAmount: parseRequestBillingAmount('net_amount', net_amount),
     aicQuantity: shouldUseAiCreditValues ? billingQty : parseNum(aic_quantity),
     aicGrossAmount: shouldUseAiCreditValues ? grossAmountValue : parseNum(aic_gross_amount),
+    inputTokens: parseTokenCount('input', input),
+    outputTokens: parseTokenCount('output', output),
+    cacheReadTokens: parseTokenCount('cache_read', cache_read),
+    cacheWriteTokens: parseTokenCount('cache_write', cache_write),
     isNonCopilotUsage: isNonCopilotCodeReviewUsage,
     usageBucket: isNonCopilotCodeReviewUsage ? NON_COPILOT_CODE_REVIEW_BUCKET : undefined,
   };

--- a/src/utils/ingestion/types.ts
+++ b/src/utils/ingestion/types.ts
@@ -60,6 +60,10 @@ export interface NormalizedRow {
   netAmount?: number;
   aicQuantity?: number;
   aicGrossAmount?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
   isNonCopilotUsage?: boolean;
   usageBucket?: SpecialUsageBucketKey;
 }
@@ -224,6 +228,29 @@ export interface FeatureUsageArtifacts {
   specialTotals: {
     nonCopilotCodeReview: number;
   };
+}
+
+/**
+ * Source-reported token counts. A field remains undefined until a valid value
+ * for that token category is encountered.
+ */
+export interface TokenBreakdown {
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+}
+
+/**
+ * Token usage aggregation results from source report fields.
+ */
+export interface TokenUsageArtifacts {
+  overall: TokenBreakdown;
+  byModel: Map<string, TokenBreakdown>;
+  byUser: Map<string, TokenBreakdown>;
+  byDayAndModel: Map<string, Map<string, TokenBreakdown>>;
+  tokenRowCount: number;
+  hasTokenData: boolean;
 }
 
 /**


### PR DESCRIPTION
Closes #222

Adds optional ingestion of the four token fields from the expanded AI usage export and surfaces them in the existing **Models** and **AI Usage** views. No new navigation entry.

## Ingestion

`input`, `output`, `cache_read` and `cache_write` are parsed when present and aggregated in a new `TokenUsageAggregator`, which runs in the existing single-pass streaming ingestion alongside the current aggregators.

The fields are strictly optional. Reports without them load exactly as before and the token UI stays hidden. A blank or malformed token cell does not reject an otherwise valid row, and an unavailable value stays distinguishable from a reported `0`: unavailable renders as `N/A`, a reported zero renders as `0`.

## Models view

- A token summary with total tokens plus each of the four fields. Each field shows its count with its share of the total in brackets.
- A per-model table ordered by total tokens, showing total tokens and each token type as a count with its share in brackets.
- A daily token chart with a local model selector.

Shares are calculated only within the relevant total — a model's four fields against that model's own total, and the summary fields against the overall total. They are never compared across models. Where the total is `0` or a value is unavailable, no share is rendered, so there is no `NaN %` or divide-by-zero `0.0 %`.

## AI Usage view

When the fields are present, the Top Spend Drivers table gains the four token columns for per-user context. The table is otherwise unchanged, and the columns do not appear for reports without token data.

## Dates

Daily token buckets use the UTC date from the report and are never converted to local time, consistent with the rest of the app.

## Scope

Token values are shown as reported. They are not used to reconstruct or infer billing, cost, savings or allocation, and no existing billing, quota or usage logic is changed — the integration is additive and gated on token data being present.

## Validation

- `npm run build`
- `npm run lint` — only the pre-existing `AdvisorySection` react-hooks warning
- `npm test -- --runInBand` — 51 suites, 314 tests

New coverage for the aggregator, the token views, the AI Usage columns, the parsing of the new fields, and the unchanged behaviour of reports without token columns.

`public/data/ai-usage-token-example.csv` is included as a sample export containing the token columns.
