### PR TITLE
Add expandable daily model consumption table

### DIFF
--- a/__tests__/components/CodingAgentOverview.test.tsx
+++ b/__tests__/components/CodingAgentOverview.test.tsx
@@ -199,6 +199,18 @@ describe('CodingAgentOverview', () => {
         isNonCopilotUsage: true,
         usageBucket: 'non_copilot_code_review',
       }),
+      buildProcessedRow({
+        user: '',
+        model: 'Coding Agent model',
+        billingQuantity: 4,
+        aicQuantity: 4,
+        grossAmount: 0.04,
+        discountAmount: 0.04,
+        netAmount: 0,
+        quotaValue: 0,
+        isNonCopilotUsage: true,
+        usageBucket: 'unattributed_ai_credit',
+      }),
     ];
 
     const dailyUserAicModelTotals = new Map<string, Map<string, Map<string, number>>>();
@@ -279,6 +291,9 @@ describe('CodingAgentOverview', () => {
     expect(within(agentRow as HTMLElement).getByText('$0.12')).toBeInTheDocument();
     expect(within(agentRow as HTMLElement).getByText('-$0.10')).toBeInTheDocument();
     expect(within(agentRow as HTMLElement).getByText('$0.02')).toBeInTheDocument();
+    const unattributedRow = within(agentTable).getByText('Unattributed AI Credits').closest('tr');
+    expect(unattributedRow).not.toBeNull();
+    expect(within(unattributedRow as HTMLElement).getByText('4.00')).toBeInTheDocument();
 
     const reviewHeading = screen.getByRole('heading', { name: 'Code Review Users' });
     const reviewTable = reviewHeading.parentElement?.nextElementSibling?.querySelector('table') as HTMLTableElement;

--- a/__tests__/components/DailyConsumptionTable.test.tsx
+++ b/__tests__/components/DailyConsumptionTable.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+
+import { DailyConsumptionTable } from '@/components/DailyConsumptionTable';
+import { PRICING } from '@/constants/pricing';
+import type { ProcessedData } from '@/types/csv';
+
+function makeProcessedRow(overrides: Partial<ProcessedData>): ProcessedData {
+  const dateKey = overrides.dateKey ?? '2026-08-01';
+  const timestamp = new Date(`${dateKey}T00:00:00Z`);
+
+  return {
+    timestamp,
+    user: 'test-user-one',
+    model: 'test-model-one',
+    requestsUsed: 0,
+    exceedsQuota: false,
+    totalQuota: '1000',
+    quotaValue: 1000,
+    iso: timestamp.toISOString(),
+    dateKey,
+    monthKey: dateKey.slice(0, 7),
+    epoch: timestamp.getTime(),
+    usageUnit: 'ai_credit',
+    ...overrides,
+  };
+}
+
+describe('DailyConsumptionTable', () => {
+  it('expands a UTC day to show the per-model AI Credits breakdown', () => {
+    const sourceRows = [
+      makeProcessedRow({
+        model: 'test-model-one',
+        aicQuantity: 100,
+        aicGrossAmount: 100 * PRICING.AI_CREDIT_USD_VALUE,
+        netAmount: 0,
+      }),
+      makeProcessedRow({
+        model: 'test-model-two',
+        aicQuantity: 50,
+        aicGrossAmount: 50 * PRICING.AI_CREDIT_USD_VALUE,
+        netAmount: 0.2,
+      }),
+    ];
+
+    render(
+      <DailyConsumptionTable
+        data={[{
+          date: '2026-08-01',
+          totalRequests: 150,
+          'test-model-one': 100,
+          'test-model-two': 50,
+        }]}
+        models={['test-model-one', 'test-model-two']}
+        isUsageBasedBilling={true}
+        sourceRows={sourceRows}
+      />
+    );
+
+    expect(screen.getByRole('heading', { name: 'Daily Consumption' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Included credits' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Aug 1, 2026/ })).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(screen.getByRole('button', { name: /Aug 1, 2026/ }));
+
+    const details = screen.getByRole('table', { name: 'Aug 1, 2026 model consumption' });
+    expect(screen.getByRole('button', { name: /Aug 1, 2026/ })).toHaveAttribute('aria-expanded', 'true');
+    expect(within(details).getByText('test-model-one')).toBeInTheDocument();
+    expect(within(details).getByText('test-model-two')).toBeInTheDocument();
+    expect(within(details).getByText('$0.20')).toBeInTheDocument();
+  });
+
+  it('uses request columns for legacy reports', () => {
+    render(
+      <DailyConsumptionTable
+        data={[{ date: '2026-08-01', totalRequests: 3, 'test-model-one': 3 }]}
+        models={['test-model-one']}
+        isUsageBasedBilling={false}
+        sourceRows={[]}
+      />
+    );
+
+    expect(screen.getByRole('columnheader', { name: 'Requests' })).toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Included credits' })).not.toBeInTheDocument();
+    expect(screen.getByText('3.00')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/DailyConsumptionTable.test.tsx
+++ b/__tests__/components/DailyConsumptionTable.test.tsx
@@ -40,6 +40,13 @@ describe('DailyConsumptionTable', () => {
         aicGrossAmount: 50 * PRICING.AI_CREDIT_USD_VALUE,
         netAmount: 0.2,
       }),
+      makeProcessedRow({
+        model: 'test-model-two',
+        usageUnit: 'request',
+        requestsUsed: 25,
+        grossAmount: 99,
+        netAmount: 99,
+      }),
     ];
 
     render(
@@ -67,6 +74,8 @@ describe('DailyConsumptionTable', () => {
     expect(within(details).getByText('test-model-one')).toBeInTheDocument();
     expect(within(details).getByText('test-model-two')).toBeInTheDocument();
     expect(within(details).getByText('$0.20')).toBeInTheDocument();
+    expect(within(details).getByText('$0.50')).toBeInTheDocument();
+    expect(within(details).queryByText('$99.00')).not.toBeInTheDocument();
   });
 
   it('uses request columns for legacy reports', () => {

--- a/__tests__/utils/modelDailyUsage.test.ts
+++ b/__tests__/utils/modelDailyUsage.test.ts
@@ -145,6 +145,45 @@ describe('buildDailyModelAicUsageFromArtifacts', () => {
     expect(result[0].totalRequests).toBe(3.75);
   });
 
+  it('includes unattributed AI Credits in the daily model total', () => {
+    const date = '2026-07-01';
+    const model = 'Gemini 3.5 Flash';
+    const usageArtifacts = makeUsageFromModelTotals({ [model]: 9364.837755 });
+    const dailyBucketsArtifacts = makeDailyAicBucketsFromNested(
+      [date],
+      [{ 'test-user-one': { [model]: 9364.837755 } }]
+    );
+    dailyBucketsArtifacts.dailyBucketModelTotals = new Map([
+      [date, new Map([
+        ['unattributed_ai_credit', new Map([[model, 18021.665685]])],
+      ])],
+    ]);
+
+    const result = buildDailyModelAicUsageFromArtifacts(dailyBucketsArtifacts, usageArtifacts);
+
+    expect(result[0][model]).toBeCloseTo(27386.50344);
+    expect(result[0].totalRequests).toBeCloseTo(27386.50344);
+  });
+
+  it('includes a day containing only unattributed AI Credits', () => {
+    const date = '2026-07-01';
+    const model = 'Gemini 3.5 Flash';
+    const usageArtifacts = makeUsageFromModelTotals({ [model]: 0 });
+    const dailyBucketsArtifacts = makeDailyAicBucketsFromNested([date], [{}]);
+    dailyBucketsArtifacts.dateRange = { min: date, max: date };
+    dailyBucketsArtifacts.months = ['2026-07'];
+    dailyBucketsArtifacts.dailyBucketModelTotals = new Map([
+      [date, new Map([
+        ['unattributed_ai_credit', new Map([[model, 18021.665685]])],
+      ])],
+    ]);
+
+    const result = buildDailyModelAicUsageFromArtifacts(dailyBucketsArtifacts, usageArtifacts);
+
+    expect(result[0][model]).toBeCloseTo(18021.665685);
+    expect(result[0].totalRequests).toBeCloseTo(18021.665685);
+  });
+
   it('builds dense multi-day UTC date-keyed AIC model totals for multiple models', () => {
     const dates = ['2025-06-30', '2025-07-01', '2025-07-02'];
     const dailyData: Array<Record<string, Record<string, number>>> = [

--- a/__tests__/utils/newFormatParsing.test.ts
+++ b/__tests__/utils/newFormatParsing.test.ts
@@ -147,9 +147,22 @@ describe('processCSVData (CSV format)', () => {
         net_amount: '0',
         total_monthly_quota: '3900',
       },
+      {
+        date: '2026-07-01',
+        username: '',
+        product: 'copilot',
+        sku: 'copilot_ai_credit',
+        model: 'Code Review model',
+        quantity: '12.5',
+        unit_type: 'ai-credits',
+        gross_amount: '0.125',
+        discount_amount: '0.125',
+        net_amount: '0',
+        total_monthly_quota: '3900',
+      },
     ]);
 
-    expect(processed).toHaveLength(1);
+    expect(processed).toHaveLength(2);
     expect(processed[0]).toMatchObject({
       user: '',
       usageUnit: 'ai_credit',
@@ -157,6 +170,11 @@ describe('processCSVData (CSV format)', () => {
       isNonCopilotUsage: true,
       usageBucket: 'unattributed_ai_credit',
       quotaValue: 0,
+    });
+    expect(processed[1]).toMatchObject({
+      model: 'Code Review model',
+      aicQuantity: 12.5,
+      usageBucket: 'unattributed_ai_credit',
     });
   });
 

--- a/__tests__/utils/newFormatParsing.test.ts
+++ b/__tests__/utils/newFormatParsing.test.ts
@@ -131,6 +131,35 @@ describe('processCSVData (CSV format)', () => {
     expect(processed[1].aicGrossAmount).toBeCloseTo(0.05447169);
   });
 
+  it('retains unattributed AI Credits rows without creating a user', () => {
+    const processed = processCSVData([
+      {
+        date: '2026-07-01',
+        username: '',
+        product: 'copilot',
+        sku: 'copilot_ai_credit',
+        model: 'Gemini 3.5 Flash',
+        quantity: '18021.665685',
+        unit_type: 'ai-credits',
+        applied_cost_per_quantity: '0.01',
+        gross_amount: '180.21665685',
+        discount_amount: '180.21665685',
+        net_amount: '0',
+        total_monthly_quota: '3900',
+      },
+    ]);
+
+    expect(processed).toHaveLength(1);
+    expect(processed[0]).toMatchObject({
+      user: '',
+      usageUnit: 'ai_credit',
+      aicQuantity: 18021.665685,
+      isNonCopilotUsage: true,
+      usageBucket: 'unattributed_ai_credit',
+      quotaValue: 0,
+    });
+  });
+
   it('maps AI Credits fields from the billing report', () => {
     const rows: CSVData[] = [
       {

--- a/__tests__/utils/nonCopilotCore.test.ts
+++ b/__tests__/utils/nonCopilotCore.test.ts
@@ -13,7 +13,7 @@ import { PRICING } from '@/constants/pricing';
 describe('non-Copilot Code Review core support', () => {
   const ctx: AggregatorContext = { pricing: PRICING };
 
-  test('normalizeRow accepts blank username only for Code Review and forces zero quota', () => {
+  test('normalizeRow accepts blank usernames for special usage and rejects other rows', () => {
     const warnings: string[] = [];
 
     const special = normalizeRow({
@@ -42,7 +42,7 @@ describe('non-Copilot Code Review core support', () => {
       quotaRaw: '0'
     }));
     expect(invalid).toBeNull();
-    expect(warnings).toContain('Blank username is only allowed for Code Review usage date=2025-10-01');
+    expect(warnings).toContain('Blank username is only allowed for Code Review or AI Credits usage date=2025-10-01');
   });
 
   test('aggregators exclude non-Copilot rows from user analytics but retain aggregate totals', () => {

--- a/__tests__/utils/usageAggregator.test.ts
+++ b/__tests__/utils/usageAggregator.test.ts
@@ -166,6 +166,8 @@ describe('processed data artifact builders', () => {
       epoch: new Date(`${row.day}T00:00:00Z`).getTime(),
       product: row.product,
       sku: row.sku,
+      usageUnit: row.usageUnit,
+      billingQuantity: row.billingQuantity,
       organization: row.organization,
       costCenter: row.costCenter,
       appliedCostPerQuantity: row.appliedCostPerQuantity,
@@ -176,6 +178,31 @@ describe('processed data artifact builders', () => {
       usageBucket: row.usageBucket,
     }));
   }
+
+  test('usage processed-data builder preserves unattributed AI Credits', () => {
+    const rows = [
+      makeNormalizedRow({
+        user: '',
+        model: 'test-model-one',
+        quantity: 0,
+        billingQuantity: 18.5,
+        usageUnit: 'ai_credit',
+        isNonCopilotUsage: true,
+        usageBucket: 'unattributed_ai_credit',
+      }),
+    ];
+
+    const output = buildUsageArtifactsFromProcessedData(toProcessedData(rows));
+
+    expect(output.users).toHaveLength(0);
+    expect(output.specialBuckets).toEqual([
+      expect.objectContaining({
+        key: 'unattributed_ai_credit',
+        totalRequests: 18.5,
+        modelBreakdown: { 'test-model-one': 18.5 },
+      }),
+    ]);
+  });
 
   test('quota processed-data builder matches QuotaAggregator license semantics', () => {
     const ctx: AggregatorContext = { pricing: PRICING };

--- a/src/components/CodingAgentOverview.tsx
+++ b/src/components/CodingAgentOverview.tsx
@@ -12,7 +12,7 @@ import {
   buildDailyCodingAgentAicUsageFromArtifacts,
   buildDailyCodingAgentUsageFromArtifacts,
   DailyBucketsArtifacts,
-  NON_COPILOT_CODE_REVIEW_LABEL,
+  getSpecialUsageBucketLabel,
 } from '@/utils/ingestion';
 import { filterDailySeriesByMonths } from '@/utils/analytics/filters';
 import { isCodeReviewModel, isCodingAgentModel } from '@/utils/productClassification';
@@ -38,15 +38,16 @@ function buildUsageBasedAgentRows(
       continue;
     }
 
-    const user = row.isNonCopilotUsage ? NON_COPILOT_CODE_REVIEW_LABEL : row.user;
+    const isSpecialUsage = Boolean(row.usageBucket);
+    const user = row.usageBucket ? getSpecialUsageBucketLabel(row.usageBucket) : row.user;
     const current = rowsByUser.get(user) ?? {
       user,
       quantity: 0,
       gross: 0,
       included: 0,
       additional: 0,
-      quota: row.isNonCopilotUsage ? 0 : row.quotaValue ?? 'unknown',
-      isSyntheticNonCopilotRow: row.isNonCopilotUsage,
+      quota: isSpecialUsage ? 0 : row.quotaValue ?? 'unknown',
+      isSyntheticNonCopilotRow: isSpecialUsage,
     };
 
     current.quantity += row.aicQuantity ?? row.billingQuantity ?? 0;

--- a/src/components/DailyConsumptionTable.tsx
+++ b/src/components/DailyConsumptionTable.tsx
@@ -1,0 +1,281 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+
+import { PRICING } from '@/constants/pricing';
+import type { ProcessedData } from '@/types/csv';
+import { getEffectiveAicQuantity } from '@/utils/aicFields';
+import { formatCurrency, formatDecimalQuantity } from '@/utils/formatters';
+import type { DailyModelUsageDatum } from '@/utils/ingestion/analytics';
+
+interface ConsumptionMetrics {
+  consumption: number;
+  includedCredits: number;
+  additionalCredits: number;
+  grossAmount: number;
+  additionalUsage: number;
+}
+
+interface DailyModelConsumptionRow extends ConsumptionMetrics {
+  model: string;
+}
+
+interface DailyConsumptionRow extends ConsumptionMetrics {
+  date: string;
+  models: DailyModelConsumptionRow[];
+}
+
+interface DailyConsumptionTableProps {
+  data: DailyModelUsageDatum[];
+  models: string[];
+  isUsageBasedBilling: boolean;
+  sourceRows: ProcessedData[];
+}
+
+function formatUtcDate(dateKey: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(`${dateKey}T00:00:00Z`));
+}
+
+function getAdditionalUsage(row: ProcessedData): number {
+  if (typeof row.netAmount === 'number') {
+    return row.netAmount;
+  }
+
+  if (typeof row.grossAmount === 'number') {
+    return Math.max(row.grossAmount - (row.discountAmount ?? 0), 0);
+  }
+
+  return 0;
+}
+
+function createMetrics(consumption: number, grossAmount: number, additionalUsage: number): ConsumptionMetrics {
+  const additionalCredits = Math.min(
+    consumption,
+    additionalUsage / PRICING.AI_CREDIT_USD_VALUE
+  );
+
+  return {
+    consumption,
+    includedCredits: Math.max(consumption - additionalCredits, 0),
+    additionalCredits,
+    grossAmount,
+    additionalUsage,
+  };
+}
+
+function buildDailyConsumptionRows(
+  data: DailyModelUsageDatum[],
+  models: string[],
+  isUsageBasedBilling: boolean,
+  sourceRows: ProcessedData[]
+): DailyConsumptionRow[] {
+  const commercialByDateAndModel = new Map<string, Map<string, { grossAmount: number; additionalUsage: number }>>();
+
+  if (isUsageBasedBilling) {
+    for (const row of sourceRows) {
+      const dateModels = commercialByDateAndModel.get(row.dateKey) ?? new Map();
+      const modelTotals = dateModels.get(row.model) ?? { grossAmount: 0, additionalUsage: 0 };
+      const aicQuantity = getEffectiveAicQuantity(row);
+
+      modelTotals.grossAmount += row.aicGrossAmount ?? aicQuantity * PRICING.AI_CREDIT_USD_VALUE;
+      modelTotals.additionalUsage += getAdditionalUsage(row);
+      dateModels.set(row.model, modelTotals);
+      commercialByDateAndModel.set(row.dateKey, dateModels);
+    }
+  }
+
+  return data.map((datum) => {
+    const dateModels = commercialByDateAndModel.get(datum.date);
+    const modelRows = models
+      .map((model) => {
+        const consumption = Number(datum[model] ?? 0);
+        const commercial = dateModels?.get(model);
+        const grossAmount = isUsageBasedBilling
+          ? commercial?.grossAmount ?? consumption * PRICING.AI_CREDIT_USD_VALUE
+          : 0;
+        const additionalUsage = commercial?.additionalUsage ?? 0;
+
+        return {
+          model,
+          ...createMetrics(consumption, grossAmount, additionalUsage),
+        };
+      })
+      .filter((row) => row.consumption > 0)
+      .sort((left, right) => right.consumption - left.consumption || left.model.localeCompare(right.model));
+
+    const grossAmount = modelRows.reduce((total, row) => total + row.grossAmount, 0);
+    const additionalUsage = modelRows.reduce((total, row) => total + row.additionalUsage, 0);
+
+    return {
+      date: datum.date,
+      models: modelRows,
+      ...createMetrics(datum.totalRequests, grossAmount, additionalUsage),
+    };
+  });
+}
+
+function ChevronIcon({ expanded }: { expanded: boolean }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={`h-4 w-4 shrink-0 text-[#636c76] transition-transform duration-150 ${expanded ? 'rotate-90' : ''}`}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      viewBox="0 0 24 24"
+    >
+      <path d="m9 18 6-6-6-6" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function UsageCells({ row, emphasized = false }: { row: ConsumptionMetrics; emphasized?: boolean }) {
+  return (
+    <>
+      <td className={`px-5 py-3.5 text-right text-sm font-mono tabular-nums ${emphasized ? 'font-semibold text-[#1f2328]' : 'text-[#636c76]'}`}>
+        {formatDecimalQuantity(row.includedCredits)}
+      </td>
+      <td className="px-5 py-3.5 text-right text-sm font-mono tabular-nums text-[#636c76]">
+        {formatDecimalQuantity(row.additionalCredits)}
+      </td>
+      <td className="px-5 py-3.5 text-right text-sm font-mono tabular-nums text-[#636c76]">
+        {formatCurrency(row.grossAmount)}
+      </td>
+      <td className={`px-5 py-3.5 text-right text-sm font-mono tabular-nums ${row.additionalUsage > 0 ? 'font-medium text-red-600' : emphasized ? 'font-semibold text-[#1f2328]' : 'text-[#636c76]'}`}>
+        {formatCurrency(row.additionalUsage)}
+      </td>
+    </>
+  );
+}
+
+export function DailyConsumptionTable({
+  data,
+  models,
+  isUsageBasedBilling,
+  sourceRows,
+}: DailyConsumptionTableProps) {
+  const [expandedDate, setExpandedDate] = useState<string | null>(null);
+  const rows = useMemo(
+    () => buildDailyConsumptionRows(data, models, isUsageBasedBilling, sourceRows),
+    [data, isUsageBasedBilling, models, sourceRows]
+  );
+  const columnCount = isUsageBasedBilling ? 5 : 2;
+
+  return (
+    <div className="overflow-hidden rounded-md border border-[#d1d9e0] bg-white">
+      <div className="border-b border-[#d1d9e0] px-5 py-4">
+        <h3 className="text-sm font-medium text-[#1f2328]">Daily Consumption</h3>
+        <p className="mt-0.5 text-xs text-[#636c76]">
+          Expand a day to view consumption by model.
+        </p>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full" aria-label="Daily consumption">
+          <thead>
+            <tr className="border-b border-[#d1d9e0] bg-[#f6f8fa]">
+              <th className="px-5 py-3 text-left text-[11px] font-semibold uppercase tracking-wider text-[#636c76]">
+                Date
+              </th>
+              {isUsageBasedBilling ? (
+                <>
+                  <th className="whitespace-nowrap px-5 py-3 text-right text-[11px] font-semibold uppercase tracking-wider text-[#636c76]">
+                    Included credits
+                  </th>
+                  <th className="whitespace-nowrap px-5 py-3 text-right text-[11px] font-semibold uppercase tracking-wider text-[#636c76]">
+                    Additional credits
+                  </th>
+                  <th className="whitespace-nowrap px-5 py-3 text-right text-[11px] font-semibold uppercase tracking-wider text-[#636c76]">
+                    Gross amount
+                  </th>
+                  <th className="whitespace-nowrap px-5 py-3 text-right text-[11px] font-semibold uppercase tracking-wider text-[#636c76]">
+                    Additional usage
+                  </th>
+                </>
+              ) : (
+                <th className="whitespace-nowrap px-5 py-3 text-right text-[11px] font-semibold uppercase tracking-wider text-[#636c76]">
+                  Requests
+                </th>
+              )}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-[#d1d9e0]">
+            {rows.map((row, index) => {
+              const isExpanded = expandedDate === row.date;
+              const detailsId = `daily-consumption-details-${index}`;
+
+              return (
+                <React.Fragment key={row.date}>
+                  <tr className="transition-colors duration-150 hover:bg-[#fcfdff]">
+                    <td className="px-5 py-3.5 text-sm font-medium text-[#1f2328]">
+                      <button
+                        type="button"
+                        className="flex w-full items-center gap-3 text-left"
+                        aria-expanded={isExpanded}
+                        aria-controls={detailsId}
+                        onClick={() => setExpandedDate(isExpanded ? null : row.date)}
+                      >
+                        <ChevronIcon expanded={isExpanded} />
+                        {formatUtcDate(row.date)}
+                      </button>
+                    </td>
+                    {isUsageBasedBilling ? (
+                      <UsageCells row={row} emphasized />
+                    ) : (
+                      <td className="px-5 py-3.5 text-right text-sm font-mono font-semibold tabular-nums text-[#1f2328]">
+                        {formatDecimalQuantity(row.consumption)}
+                      </td>
+                    )}
+                  </tr>
+                  {isExpanded && (
+                    <tr>
+                      <td id={detailsId} colSpan={columnCount} className="p-0">
+                        <table className="min-w-full bg-[#f6f8fa]" aria-label={`${formatUtcDate(row.date)} model consumption`}>
+                          <thead>
+                            <tr className="border-y border-[#d1d9e0]">
+                              <th className="px-12 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-[#636c76]">
+                                Model
+                              </th>
+                              {isUsageBasedBilling ? (
+                                <>
+                                  <th className="whitespace-nowrap px-5 py-2.5 text-right text-[11px] font-semibold uppercase tracking-wider text-[#636c76]">Included credits</th>
+                                  <th className="whitespace-nowrap px-5 py-2.5 text-right text-[11px] font-semibold uppercase tracking-wider text-[#636c76]">Additional credits</th>
+                                  <th className="whitespace-nowrap px-5 py-2.5 text-right text-[11px] font-semibold uppercase tracking-wider text-[#636c76]">Gross amount</th>
+                                  <th className="whitespace-nowrap px-5 py-2.5 text-right text-[11px] font-semibold uppercase tracking-wider text-[#636c76]">Additional usage</th>
+                                </>
+                              ) : (
+                                <th className="whitespace-nowrap px-5 py-2.5 text-right text-[11px] font-semibold uppercase tracking-wider text-[#636c76]">Requests</th>
+                              )}
+                            </tr>
+                          </thead>
+                          <tbody className="divide-y divide-[#d1d9e0]">
+                            {row.models.map((model) => (
+                              <tr key={model.model}>
+                                <td className="px-12 py-3 text-sm font-medium text-[#1f2328]">{model.model}</td>
+                                {isUsageBasedBilling ? (
+                                  <UsageCells row={model} />
+                                ) : (
+                                  <td className="px-5 py-3 text-right text-sm font-mono tabular-nums text-[#636c76]">
+                                    {formatDecimalQuantity(model.consumption)}
+                                  </td>
+                                )}
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  )}
+                </React.Fragment>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/DailyConsumptionTable.tsx
+++ b/src/components/DailyConsumptionTable.tsx
@@ -78,6 +78,10 @@ function buildDailyConsumptionRows(
 
   if (isUsageBasedBilling) {
     for (const row of sourceRows) {
+      if (row.usageUnit !== 'ai_credit') {
+        continue;
+      }
+
       const dateModels = commercialByDateAndModel.get(row.dateKey) ?? new Map();
       const modelTotals = dateModels.get(row.model) ?? { grossAmount: 0, additionalUsage: 0 };
       const aicQuantity = getEffectiveAicQuantity(row);

--- a/src/components/ModelUsageTrendsOverview.tsx
+++ b/src/components/ModelUsageTrendsOverview.tsx
@@ -2,6 +2,7 @@
 
 import React, { useMemo } from 'react';
 
+import { DailyConsumptionTable } from '@/components/DailyConsumptionTable';
 import { useAnalysisContext } from '@/context/AnalysisContext';
 import { ModelDailyStackedChart } from '@/components/charts/ModelDailyStackedChart';
 import { filterDailySeriesByMonths } from '@/utils/analytics/filters';
@@ -151,6 +152,15 @@ export function ModelUsageTrendsOverview() {
           </div>
         )}
       </div>
+
+      {data.length > 0 && models.length > 0 && (
+        <DailyConsumptionTable
+          data={data}
+          models={models}
+          isUsageBasedBilling={isUsageBasedBilling}
+          sourceRows={aggregateProcessedData}
+        />
+      )}
     </div>
   );
 }

--- a/src/types/csv.ts
+++ b/src/types/csv.ts
@@ -49,7 +49,7 @@ export interface ProcessedData {
   aicQuantity?: number;
   aicGrossAmount?: number;
   isNonCopilotUsage?: boolean;
-  usageBucket?: 'non_copilot_code_review';
+  usageBucket?: 'non_copilot_code_review' | 'unattributed_ai_credit';
 }
 
 export interface AnalysisResults {

--- a/src/utils/ingestion/DailyBucketsAggregator.ts
+++ b/src/utils/ingestion/DailyBucketsAggregator.ts
@@ -89,8 +89,11 @@ export class DailyBucketsAggregator implements Aggregator<DailyBucketsArtifacts>
     this.months.add(day.slice(0, 7));
 
     if (row.isNonCopilotUsage && row.usageBucket) {
-      DailyBucketsAggregator.inc2Level(this.dailyBucketTotals, day, row.usageBucket, quantity);
-      DailyBucketsAggregator.inc3Level(this.dailyBucketModelTotals, day, row.usageBucket, model, quantity);
+      const bucketQuantity = row.usageUnit === 'ai_credit'
+        ? row.aicQuantity ?? row.billingQuantity ?? 0
+        : quantity;
+      DailyBucketsAggregator.inc2Level(this.dailyBucketTotals, day, row.usageBucket, bucketQuantity);
+      DailyBucketsAggregator.inc3Level(this.dailyBucketModelTotals, day, row.usageBucket, model, bucketQuantity);
       return;
     }
 

--- a/src/utils/ingestion/UsageAccumulator.ts
+++ b/src/utils/ingestion/UsageAccumulator.ts
@@ -1,5 +1,5 @@
 import {
-  NON_COPILOT_CODE_REVIEW_LABEL,
+  getSpecialUsageBucketLabel,
   type SpecialUsageBucketAggregate,
   type SpecialUsageBucketKey,
   type UsageArtifacts,
@@ -10,6 +10,8 @@ export interface UsageAccumulationRow {
   user: string;
   model: string;
   quantity: number;
+  billingQuantity?: number;
+  usageUnit?: 'request' | 'ai_credit' | 'unknown';
   organization?: string;
   costCenter?: string;
   isNonCopilotUsage?: boolean;
@@ -38,15 +40,18 @@ export class UsageAccumulator {
       if (!bucket) {
         bucket = {
           key: row.usageBucket,
-          label: NON_COPILOT_CODE_REVIEW_LABEL,
+          label: getSpecialUsageBucketLabel(row.usageBucket),
           totalRequests: 0,
           modelBreakdown: {},
           quotaValue: 0,
         };
         this.specialBuckets.set(row.usageBucket, bucket);
       }
-      bucket.totalRequests += row.quantity;
-      bucket.modelBreakdown[row.model] = (bucket.modelBreakdown[row.model] || 0) + row.quantity;
+      const bucketQuantity = row.usageUnit === 'ai_credit'
+        ? row.billingQuantity ?? 0
+        : row.quantity;
+      bucket.totalRequests += bucketQuantity;
+      bucket.modelBreakdown[row.model] = (bucket.modelBreakdown[row.model] || 0) + bucketQuantity;
       this.modelTotals.set(row.model, (this.modelTotals.get(row.model) || 0) + row.quantity);
       return;
     }

--- a/src/utils/ingestion/analytics.ts
+++ b/src/utils/ingestion/analytics.ts
@@ -96,6 +96,8 @@ export function buildUsageArtifactsFromProcessedData(filtered: ProcessedData[]):
       user: r.user,
       model: r.model,
       quantity: r.requestsUsed,
+      billingQuantity: r.billingQuantity,
+      usageUnit: r.usageUnit,
       organization: r.organization,
       costCenter: r.costCenter,
       isNonCopilotUsage: r.isNonCopilotUsage,

--- a/src/utils/ingestion/analytics.ts
+++ b/src/utils/ingestion/analytics.ts
@@ -23,6 +23,7 @@ import { calculateOverageRequests, calculateOverageCost } from '@/utils/userCalc
 import {
   type BillingArtifacts,
   NON_COPILOT_CODE_REVIEW_BUCKET,
+  UNATTRIBUTED_AI_CREDIT_BUCKET,
   type DailyBucketsArtifacts,
   type Aggregator,
   type FeatureUsageArtifacts,
@@ -451,7 +452,8 @@ export interface DailyModelUsageDatum {
 function buildDailyModelUsageFromTotals(
   daily: DailyBucketsArtifacts,
   usage: UsageArtifacts,
-  dailyUserModelTotalsMap: Map<string, Map<string, Map<string, number>>> | undefined
+  dailyUserModelTotalsMap: Map<string, Map<string, Map<string, number>>> | undefined,
+  specialBucketKey?: typeof UNATTRIBUTED_AI_CREDIT_BUCKET
 ): DailyModelUsageDatum[] {
   if (!daily.dateRange || !dailyUserModelTotalsMap) return [];
 
@@ -464,6 +466,9 @@ function buildDailyModelUsageFromTotals(
   const result: DailyModelUsageDatum[] = [];
   for (const date of dates) {
     const dayUserMap = dailyUserModelTotalsMap.get(date);
+    const specialModelMap = specialBucketKey
+      ? daily.dailyBucketModelTotals?.get(date)?.get(specialBucketKey)
+      : undefined;
     const row: DailyModelUsageDatum = { date, totalRequests: 0 };
     let dayTotal = 0;
 
@@ -474,6 +479,7 @@ function buildDailyModelUsageFromTotals(
           modelTotal += modelMap.get(model) || 0;
         }
       }
+      modelTotal += specialModelMap?.get(model) ?? 0;
       row[model] = modelTotal;
       dayTotal += modelTotal;
     }
@@ -507,7 +513,12 @@ export function buildDailyModelAicUsageFromArtifacts(
   daily: DailyBucketsArtifacts,
   usage: UsageArtifacts
 ): DailyModelUsageDatum[] {
-  return buildDailyModelUsageFromTotals(daily, usage, daily.dailyUserAicModelTotals);
+  return buildDailyModelUsageFromTotals(
+    daily,
+    usage,
+    daily.dailyUserAicModelTotals,
+    UNATTRIBUTED_AI_CREDIT_BUCKET
+  );
 }
 
 // -----------------------------

--- a/src/utils/ingestion/billingAccumulator.ts
+++ b/src/utils/ingestion/billingAccumulator.ts
@@ -10,7 +10,7 @@ import {
   BillingGroupTotals,
   BillingOverageTotals,
   BillingUserTotals,
-  NON_COPILOT_CODE_REVIEW_LABEL,
+  getSpecialUsageBucketLabel,
   SpecialBillingBucketTotals,
   SpecialUsageBucketKey,
   UNASSIGNED_BILLING_GROUP,
@@ -160,7 +160,7 @@ export class BillingAccumulator {
       if (!entry) {
         entry = {
           key: billingRow.usageBucket,
-          label: NON_COPILOT_CODE_REVIEW_LABEL,
+          label: getSpecialUsageBucketLabel(billingRow.usageBucket),
           quantity: 0,
           overage: createBillingOverageTotals(),
           quotaValue: 0,

--- a/src/utils/ingestion/normalizeRow.ts
+++ b/src/utils/ingestion/normalizeRow.ts
@@ -12,6 +12,7 @@ import { normalizeDateToIso, type DateNormalizer } from './dateNormalization';
 import {
   NON_COPILOT_CODE_REVIEW_BUCKET,
   NormalizedRow,
+  UNATTRIBUTED_AI_CREDIT_BUCKET,
 } from './types';
 
 /**
@@ -66,16 +67,23 @@ export function normalizeRow(
   }
 
   const trimmedUsername = username.trim();
-  const isNonCopilotCodeReviewUsage = trimmedUsername.length === 0 && isCodeReviewModel(model);
-
-  if (trimmedUsername.length === 0 && !isNonCopilotCodeReviewUsage) {
-    warnings.push(`Blank username is only allowed for Code Review usage date=${date}`);
-    return null;
-  }
-  
   const unitType = typeof unit_type === 'string' && unit_type.trim() !== '' ? unit_type.trim() : undefined;
   const skuValue = typeof sku === 'string' ? sku : undefined;
   const usageUnit = getUsageUnitKind(unitType, skuValue);
+  const isNonCopilotCodeReviewUsage = trimmedUsername.length === 0 && isCodeReviewModel(model);
+  const isUnattributedAiCreditUsage = trimmedUsername.length === 0 && usageUnit === 'ai_credit';
+  const isSpecialUsage = isNonCopilotCodeReviewUsage || isUnattributedAiCreditUsage;
+  const usageBucket = isNonCopilotCodeReviewUsage
+    ? NON_COPILOT_CODE_REVIEW_BUCKET
+    : isUnattributedAiCreditUsage
+      ? UNATTRIBUTED_AI_CREDIT_BUCKET
+      : undefined;
+
+  if (trimmedUsername.length === 0 && !isSpecialUsage) {
+    warnings.push(`Blank username is only allowed for Code Review or AI Credits usage date=${date}`);
+    return null;
+  }
+
   const shouldUseRequestValues = usageUnit === 'request';
   const shouldUseAiCreditValues = usageUnit === 'ai_credit';
   const shouldUseUsageValues = usageUnit !== 'unknown';
@@ -90,7 +98,7 @@ export function normalizeRow(
   const billingQty = shouldUseUsageValues ? parsedQty : 0;
   
   // Parse quota if present
-  const quotaValue = isNonCopilotCodeReviewUsage
+  const quotaValue = isSpecialUsage
     ? 0
     : shouldUseUsageValues && total_monthly_quota && typeof total_monthly_quota === 'string'
       ? parseQuotaValue(total_monthly_quota)
@@ -122,7 +130,7 @@ export function normalizeRow(
     model,
     quantity: qty,
     billingQuantity: billingQty,
-    quotaRaw: isNonCopilotCodeReviewUsage
+    quotaRaw: isSpecialUsage
       ? '0'
       : shouldUseUsageValues && typeof total_monthly_quota === 'string'
         ? total_monthly_quota
@@ -141,7 +149,7 @@ export function normalizeRow(
     netAmount: parseRequestBillingAmount('net_amount', net_amount),
     aicQuantity: shouldUseAiCreditValues ? billingQty : parseNum(aic_quantity),
     aicGrossAmount: shouldUseAiCreditValues ? grossAmountValue : parseNum(aic_gross_amount),
-    isNonCopilotUsage: isNonCopilotCodeReviewUsage,
-    usageBucket: isNonCopilotCodeReviewUsage ? NON_COPILOT_CODE_REVIEW_BUCKET : undefined,
+    isNonCopilotUsage: isSpecialUsage,
+    usageBucket,
   };
 }

--- a/src/utils/ingestion/normalizeRow.ts
+++ b/src/utils/ingestion/normalizeRow.ts
@@ -70,8 +70,9 @@ export function normalizeRow(
   const unitType = typeof unit_type === 'string' && unit_type.trim() !== '' ? unit_type.trim() : undefined;
   const skuValue = typeof sku === 'string' ? sku : undefined;
   const usageUnit = getUsageUnitKind(unitType, skuValue);
-  const isNonCopilotCodeReviewUsage = trimmedUsername.length === 0 && isCodeReviewModel(model);
   const isUnattributedAiCreditUsage = trimmedUsername.length === 0 && usageUnit === 'ai_credit';
+  const isNonCopilotCodeReviewUsage =
+    trimmedUsername.length === 0 && !isUnattributedAiCreditUsage && isCodeReviewModel(model);
   const isSpecialUsage = isNonCopilotCodeReviewUsage || isUnattributedAiCreditUsage;
   const usageBucket = isNonCopilotCodeReviewUsage
     ? NON_COPILOT_CODE_REVIEW_BUCKET

--- a/src/utils/ingestion/types.ts
+++ b/src/utils/ingestion/types.ts
@@ -7,13 +7,23 @@ import type { UsageUnitKind } from '@/utils/unitType';
 
 export const NON_COPILOT_CODE_REVIEW_BUCKET = 'non_copilot_code_review' as const;
 export const NON_COPILOT_CODE_REVIEW_LABEL = 'Non-Copilot Users' as const;
+export const UNATTRIBUTED_AI_CREDIT_BUCKET = 'unattributed_ai_credit' as const;
+export const UNATTRIBUTED_AI_CREDIT_LABEL = 'Unattributed AI Credits' as const;
 export const UNASSIGNED_BILLING_GROUP = 'Unassigned' as const;
 
-export type SpecialUsageBucketKey = typeof NON_COPILOT_CODE_REVIEW_BUCKET;
+export type SpecialUsageBucketKey =
+  | typeof NON_COPILOT_CODE_REVIEW_BUCKET
+  | typeof UNATTRIBUTED_AI_CREDIT_BUCKET;
+
+export function getSpecialUsageBucketLabel(key: SpecialUsageBucketKey): string {
+  return key === NON_COPILOT_CODE_REVIEW_BUCKET
+    ? NON_COPILOT_CODE_REVIEW_LABEL
+    : UNATTRIBUTED_AI_CREDIT_LABEL;
+}
 
 export interface SpecialUsageBucketAggregate {
   key: SpecialUsageBucketKey;
-  label: typeof NON_COPILOT_CODE_REVIEW_LABEL;
+  label: string;
   totalRequests: number;
   modelBreakdown: Record<string, number>;
   quotaValue: 0;
@@ -21,7 +31,7 @@ export interface SpecialUsageBucketAggregate {
 
 export interface SpecialBillingBucketTotals {
   key: SpecialUsageBucketKey;
-  label: typeof NON_COPILOT_CODE_REVIEW_LABEL;
+  label: string;
   quantity: number;
   overage: BillingOverageTotals;
   gross?: number;


### PR DESCRIPTION
Daily model consumption was only visible in the chart, making exact per-day and per-model values difficult to inspect. This adds an expandable light-theme table below the chart and fixes unattributed AI Credit rows that were previously dropped when their username was blank.

## Summary

- Add daily rows with expandable per-model breakdowns.
- Show included credits, additional credits, gross amount, and additional usage for AI Credit reports, while preserving request columns for legacy reports.
- Preserve UTC date handling throughout the table.
- Route blank-username AI Credit rows through an unattributed usage bucket so they contribute to model and billing totals without creating a synthetic user.
- Keep AI Credit special-bucket classification and usage-based cost aggregation correct in mixed exports.
- Preserve unattributed labels in agent tables and parity between streaming and processed-data artifact builders.
- Cover attributed, mixed, and unattributed-only daily aggregation paths with regression tests.
- Align the existing blank-username warning test with AI Credit support.

## Commits

| Commit | Change |
|--------|--------|
| `feat: add expandable daily consumption table` | Adds the accessible daily table and per-model drill-down for both AI Credit and legacy request reports. |
| `fix: include unattributed AI credit usage` | Retains blank-username AI Credit rows in daily model and billing aggregation without counting them as users. |
| `test: align blank username warning expectation` | Updates the stale warning assertion after blank usernames became valid for AI Credit usage. |
| `fix: address daily consumption review feedback` | Corrects AI Credit bucket precedence, mixed-export billing filters, processed artifact parity, and special-row labels. |

## Validation

- `npm run build`
- `npm run lint` (passes with one pre-existing hook dependency warning)
- `npm run test -- --runInBand` (305 passed, 1 skipped)